### PR TITLE
Introduce release action

### DIFF
--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -1,0 +1,57 @@
+name: Build to release branch
+description: Merge and build a source branch into a releasable, fully-built branch.
+
+inputs:
+  source_branch:
+    description: Name of source branch.
+    required: true
+  release_branch:
+    description: Name of target release branch. Will be updated with a merge commit including built code.
+    required: true
+  built_asset_paths:
+    description: Generated assets to include in release branch commit. Overrides .gitignore.
+    required: true
+  build_script:
+    description: Command to run to build code. "npm run build" by default.
+    required: false
+
+runs:
+  using: composite
+
+  steps:
+    - name: Configure git
+      shell: bash
+      run: |
+        git config user.name "Your friendly neighborhood GH Actions Bot"
+        git config user.email "<>"
+
+    - name: Check out release branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.release_branch }}
+        fetch-depth: 0
+
+    - name: Merge source into release branch
+      shell: bash
+      # Simulate "-s theirs", which doesn't exist in git for reasons.
+      # https://web.archive.org/web/20131126171744/http://www.seanius.net/blog/2011/02/git-merge-s-theirs/
+      run: |
+        git fetch origin ${{ inputs.source_branch }}
+        git fetch origin ${{ inputs.release_branch }}
+        git checkout ${{ inputs.source_branch }}
+        git checkout ${{ inputs.release_branch }}
+        git merge -s ours ${{ inputs.source_branch }}
+        git diff --binary ${{ inputs.source_branch }} | git apply -R --index
+        git commit --amend -m "Merge branch '${{ inputs.source_branch }}' into '${{ inputs.release_branch }}'"
+    
+    - name: Build code
+      shell: bash
+      run: ${{ inputs.build_script }}
+
+    - name: Update release branch
+      shell: bash
+      run: |
+        echo "${{ inputs.built_asset_paths }}"
+        git add -f ${{ inputs.built_asset_paths }}
+        git commit --amend -m "Build to 'release' from ${{ inputs.source_branch }}#$( git rev-parse --short ${{ inputs.source_branch }} )"
+        git push origin ${{ inputs.release_branch }}:${{ inputs.release_branch }}

--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -33,7 +33,8 @@ runs:
 
     - name: Merge source into release branch
       shell: bash
-      # Simulate "-s theirs", which doesn't exist in git for reasons.
+      # Simulate "-s theirs", which doesn't exist in git for sensible reasons
+      # which do not apply to our current situation.
       # https://web.archive.org/web/20131126171744/http://www.seanius.net/blog/2011/02/git-merge-s-theirs/
       run: |
         git fetch origin ${{ inputs.source_branch }}
@@ -43,7 +44,7 @@ runs:
         git merge -s ours ${{ inputs.source_branch }}
         git diff --binary ${{ inputs.source_branch }} | git apply -R --index
         git commit --amend -m "Merge branch '${{ inputs.source_branch }}' into '${{ inputs.release_branch }}'"
-    
+
     - name: Build code
       shell: bash
       run: ${{ inputs.build_script }}
@@ -51,7 +52,6 @@ runs:
     - name: Update release branch
       shell: bash
       run: |
-        echo "${{ inputs.built_asset_paths }}"
         git add -f ${{ inputs.built_asset_paths }}
         git commit --amend -m "Build to 'release' from ${{ inputs.source_branch }}#$( git rev-parse --short ${{ inputs.source_branch }} )"
         git push origin ${{ inputs.release_branch }}:${{ inputs.release_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: "Update release branch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,15 @@ name: Release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
 
 jobs:
   release:
-    name: Build project
+    name: Update release branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
@@ -18,18 +18,35 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-      - name: Update release branch
-        uses: technote-space/release-github-actions@v7
+      - name: Check out release branch
+        uses: actions/checkout@v3
         with:
-          BRANCH_NAME: release
-          BUILD_COMMAND_TARGET: 'build'
-          CLEAN_TEST_TAG: true
-          CLEAN_TARGETS: .[!.]*,__tests__,src,package.json,package-lock.json,node_modules,tests,*.xml.dist
-          COMMIT_MESSAGE: "Built release for ${{ steps.get_version.outputs.VERSION }}. For a full change log look at the notes within the original/${{ steps.get_version.outputs.VERSION }} release."
-          CREATE_MAJOR_VERSION_TAG: false
-          CREATE_MINOR_VERSION_TAG: false
-          CREATE_PATCH_VERSION_TAG: false
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORIGINAL_TAG_PREFIX: original/
-          OUTPUT_BUILD_INFO_FILENAME: build.json
-          TEST_TAG_PREFIX: test/
+          ref: release
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "Your friendly neighborhood GH Actions Bot"
+          git config user.email "<>"
+
+      - name: Merge production branch
+        run: |
+          git fetch origin main
+          git checkout main
+          git checkout -b tmp main
+          git merge -s ours release
+          git checkout release
+          git merge tmp
+          git commit --amend -m "Merge branch 'main' into 'release'"
+          git branch -D tmp
+      
+      - name: Build code
+        run: |
+          npm ci
+          npm run build:gulp
+
+      - name: Update release branch
+        run: |
+          git add -f ./*.css package-lock.json map assets/dist
+          git commit --amend -m "Build release from main#$( git rev-parse --short main )"
+          git push origin release:release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,46 +7,22 @@ on:
 
 jobs:
   release:
-    name: Update release branch
+    name: "Update release branch"
     runs-on: ubuntu-latest
     steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Check out release branch
-        uses: actions/checkout@v3
+      - name: Merge and build
+        uses: ./.github/actions/build-to-release-branch
         with:
-          ref: release
-          fetch-depth: 0
-
-      - name: Configure git
-        run: |
-          git config user.name "Your friendly neighborhood GH Actions Bot"
-          git config user.email "<>"
-
-      - name: Merge production branch
-        run: |
-          git fetch origin main
-          git checkout main
-          git checkout -b tmp main
-          git merge -s ours release
-          git checkout release
-          git merge tmp
-          git commit --amend -m "Merge branch 'main' into 'release'"
-          git branch -D tmp
-      
-      - name: Build code
-        run: |
-          npm ci
-          npm run build:gulp
-
-      - name: Update release branch
-        run: |
-          git add -f ./*.css package-lock.json map assets/dist
-          git commit --amend -m "Build release from main#$( git rev-parse --short main )"
-          git push origin release:release
+          source_branch: main
+          release_branch: release
+          built_asset_paths: ./*.css package-lock.json map assets/dist
+          build_script: |
+            npm ci
+            npm run build:gulp


### PR DESCRIPTION
This PR introduces a GitHub action to build generated assets into the `release` branch every time code is merge to `main`. It assumes that `release` branch commits will be tagged for release via Composer or else included in other projects as a submodule.

This is the history of the release branch when using this action, as [tested earlier today in this repository](https://github.com/wikimedia/shiro-wordpress-theme/actions):

```
*   eede1a3e (HEAD -> release, origin/release) Build to 'release' from main#5b2685f8
|\  
| * 5b2685f8 (origin/main, main) Bump build
| * 8e976671 Use shorter ref name, full disambiguation not needed
* | 1672b027 Build to 'release' from main#d75887a1
|\| 
| * d75887a1 Remove test code
* | 91cafb02 Build to 'release' from main#6aede1f4
|\| 
| * 6aede1f4 Change concurrency group to be more general
* | 4853956b Build to 'release' from main#1796000b
|\| 
| * 1796000b Bump
| * 656b86f4 Add concurrency setting
```
Every change to main that gets pushed, `release` gets updated with the latest source branch code and then any generated assets are force-committed.

The `action.yml` file could be extracted into a reusable composite action, but I didn't want to take that step until we were certain we'd need it.