### PR TITLE
Add release branch protection workflow

### DIFF
--- a/.github/workflows/protect-release-branch.yml
+++ b/.github/workflows/protect-release-branch.yml
@@ -1,0 +1,15 @@
+name: Branch protection
+on:
+  pull_request:
+    branches:
+      - 'release'
+
+jobs:
+  release:
+    name: Do not merge the Release branch into other branches
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          echo "The release branch is automatically maintained based on merges to 'main' and should not be the source for a pull request."
+          exit 1


### PR DESCRIPTION
This workflow iterates on a suggestion from @goldenapples in #1 that it would be bad for the release branch to be merged back into other branches. While it is not possible to prevent a branch from being used as a merge source in GitHub, this action should fail the PR if such a merge is attempted.

What it looks like if the action fails:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/442115/201215734-b3aaa2a4-bfad-4f99-b31c-b51f368516f8.png">
