### PR TITLE
Add theme composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+vendor/
 map
 assets/dist/
 editor-style.css

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,15 @@
     "name": "wikimedia/shiro-wordpress-theme",
     "version": "1.0.0",
     "description": "Wikimedia Foundation website theme.",
+    "license": "GPL-2.0-or-later",
     "minimum-stability": "stable",
     "type": "wordpress-theme",
+    "repositories": [
+        {
+            "type": "github",
+            "url": "https://github.com/wikimedia/shiro-wordpress-theme.git"
+        }
+    ],
     "config": {
         "allow-plugins": {
             "composer/installers": true

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "wikimedia/shiro-wordpress-theme",
+    "version": "1.0.0",
+    "description": "Wikimedia Foundation website theme.",
+    "minimum-stability": "stable",
+    "type": "wordpress-theme",
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "cbda823fb94a54d9d4479265203b5392",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cbda823fb94a54d9d4479265203b5392",
+    "content-hash": "5f8cb1ae87e9ed8999b459bf1842fc1d",
     "packages": [],
     "packages-dev": [],
     "aliases": [],


### PR DESCRIPTION
It may be necessary for the Wikimedia sites to consume this theme as a composer dependency and not a submodule, so this PR adds a `composer.json`. This is required to install the theme via composer, even from a VCS source (that is, not using Packagist).