### PR TITLE
Address PHPCS errors in files touched by #4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,6 +42,10 @@ jobs:
         if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' && steps.cache-php-dependencies.outputs.cache-hit != 'true' }}
         run: composer install --no-progress --no-interaction --no-ansi
 
+      - name: Make Composer packages available globally
+        if: ${{ toJSON( steps.paths.outputs.changes ) != '"[]"' }}
+        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
       - name: Check syntax
         if: ${{ steps.paths.outputs.phpcs == 'true' }}
         run: parallel-lint --exclude .git --exclude .github --exclude vendor .
@@ -52,9 +56,9 @@ jobs:
         # outputs.phpcs so it will re-run if standards or dependencies change.
         if: ${{ steps.paths.outputs.php == 'true' }}
         run: |
-          vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml ${{ steps.paths.outputs.php_files }}
+          phpcs --report-full --report-checkstyle=./phpcs-report.xml ${{ steps.paths.outputs.php_files }}
 
       - name: Report PHPCS results
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: |
-          vendor/bin/cs2pr ./phpcs-report.xml
+          cs2pr ./phpcs-report.xml

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     },
     "require-dev": {
-        "automattic/vipwpcs": "^1.0",
+        "automattic/vipwpcs": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
         "phpcompatibility/phpcompatibility-wp": "^1.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "wp-coding-standards/wpcs": "^1.0",
+        "wp-coding-standards/wpcs": "^2.0",
         "staabm/annotate-pull-request-from-checkstyle": "^1.8"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,35 +4,36 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19b9a4e2ce103bc5774d17851d82a8ff",
+    "content-hash": "d15adf25f56bdaceecc2295ac7d77135",
     "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "1.0.0",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "8544a94c32f990b6669f2c7f034d4ba75ccbb558"
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/8544a94c32f990b6669f2c7f034d4ba75ccbb558",
-                "reference": "8544a94c32f990b6669f2c7f034d4ba75ccbb558",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "squizlabs/php_codesniffer": "^3.2.3",
-                "wp-coding-standards/wpcs": "1.*"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpunit/phpunit": "^5 || ^6 || ^7"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -56,7 +57,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2019-04-24T21:34:09+00:00"
+            "time": "2021-09-29T16:20:23+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -241,6 +242,64 @@
             "time": "2018-07-16T22:10:02+00:00"
         },
         {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "62730888d225d55a613854b6a76fb1f9f57d1618"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/62730888d225d55a613854b6a76fb1f9f57d1618",
+                "reference": "62730888d225d55a613854b6a76fb1f9f57d1618",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2022-10-05T23:31:46+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -345,27 +404,30 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "^9.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -375,7 +437,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -385,11 +447,11 @@
                 "wordpress"
             ],
             "support": {
-                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2018-12-18T09:43:51+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/functions.php
+++ b/functions.php
@@ -154,7 +154,7 @@ function wmf_scripts() {
 	}
 
 	if ( is_page_template( 'page-data.php' ) ) {
-		wp_enqueue_script( 'd3', get_template_directory_uri() . '/assets/src/datavisjs/libraries/d3.min.js', array( ), '0.0.1', true );
+		wp_enqueue_script( 'd3', get_template_directory_uri() . '/assets/src/datavisjs/libraries/d3.min.js', [], '0.0.1', true );
 		wp_enqueue_script( 'datavis', get_template_directory_uri() . '/assets/dist/datavis.min.js', array( 'jquery' ), '0.0.1', true );
 	}
 }
@@ -165,20 +165,20 @@ add_action( 'wp_enqueue_scripts', 'wmf_scripts' );
  */
 function wmf_add_piwik_analytics() {
 	?>
-        <!-- Matomo -->
-        <script type="text/javascript">
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-        var u="//piwik.wikimedia.org/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
-        _paq.push(['setSiteId', '<?php echo esc_attr( get_site_option( 'matomo_siteid' ) ) ?>']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-        })();
-        </script>
-        <!-- End Matomo Code -->
+	<!-- Matomo -->
+	<script type="text/javascript">
+	var _paq = window._paq = window._paq || [];
+	/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+	_paq.push(['trackPageView']);
+	_paq.push(['enableLinkTracking']);
+	(function() {
+	var u="//piwik.wikimedia.org/";
+	_paq.push(['setTrackerUrl', u+'piwik.php']);
+	_paq.push(['setSiteId', '<?php echo esc_attr( get_site_option( 'matomo_siteid' ) ); ?>']);
+	var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript'; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+	})();
+	</script>
+	<!-- End Matomo Code -->
 	<?php
 }
 add_action( 'wp_footer', 'wmf_add_piwik_analytics' );

--- a/functions.php
+++ b/functions.php
@@ -371,10 +371,11 @@ require_once get_template_directory() . '/inc/stories.php';
 Stories_Customisations\init();
 
 /**
- * Modify the document title for the search and 404 pages
+ * Modify the document title for the 404 page
+ *
+ * @param array $title_parts Document title parts.
+ * @return array Filtered array.
  */
-
-// 404 page
 function wmf_filter_wp_404title( $title_parts ) {
 	if ( is_404() ) {
 		$title_parts['title'] = get_theme_mod( 'wmf_404_message', __( '404 Error', 'shiro-admin' ) );
@@ -386,10 +387,22 @@ function wmf_filter_wp_404title( $title_parts ) {
 // Hook into document_title_parts
 add_filter( 'document_title_parts', 'wmf_filter_wp_404title' );
 
-// Search page
+/**
+ * Modify the document title for the search page
+ *
+ * @param array $title_parts Document title parts.
+ * @return array Filtered array.
+ */
 function wmf_filter_wp_searchtitle( $title_parts ) {
 	if ( is_search() ) {
-		$title_parts['title'] = sprintf( __( get_theme_mod( 'wmf_search_results_copy', __( 'Search results for %s', 'shiro-admin' ) ), 'shiro' ), get_search_query() );
+		$title_parts['title'] = sprintf(
+			get_theme_mod(
+				'wmf_search_results_copy',
+				/* translators: %s: the search query. */
+				__( 'Search results for %s', 'shiro-admin' )
+			),
+			get_search_query()
+		);
 	}
 
 	return $title_parts;

--- a/functions.php
+++ b/functions.php
@@ -487,7 +487,7 @@ add_filter( 'nav_menu_item_args', 'wmf_filter_nav_menu_items', 10, 3 );
 /**
  * Add reusable blocks link to admin menu.
  */
-function link_reusable_blocks_url() {
+function shiro_link_reusable_blocks_url() {
 	add_menu_page(
 		esc_html__( 'Reusable Blocks', 'shiro-admin' ),
 		esc_html__( 'Reusable Blocks', 'shiro-admin' ),
@@ -498,7 +498,7 @@ function link_reusable_blocks_url() {
 	);
 }
 
-add_action( 'admin_menu', 'link_reusable_blocks_url' );
+add_action( 'admin_menu', 'shiro_link_reusable_blocks_url' );
 
 /**
  * Add page slug as body class.

--- a/functions.php
+++ b/functions.php
@@ -88,6 +88,7 @@ function wmf_setup() {
 
 	// Warn if required environment is not satisfied.
 	if ( ! function_exists( 'Asset_Loader\enqueue_asset' ) ) {
+		// phpcs:ignore
 		trigger_error( 'This theme expects the humanmade/asset-loader plugin to be installed and active.' );
 	}
 }
@@ -374,28 +375,28 @@ Stories_Customisations\init();
  */
 
 // 404 page
-function theme_slug_filter_wp_404title( $title_parts ) {
-    if ( is_404() ) {
-        $title_parts['title'] = get_theme_mod( 'wmf_404_message', __( '404 Error', 'shiro-admin' ) );
-    }
+function wmf_filter_wp_404title( $title_parts ) {
+	if ( is_404() ) {
+		$title_parts['title'] = get_theme_mod( 'wmf_404_message', __( '404 Error', 'shiro-admin' ) );
+	}
 
-    return $title_parts;
+	return $title_parts;
 }
 
 // Hook into document_title_parts
-add_filter( 'document_title_parts', 'theme_slug_filter_wp_404title' );
+add_filter( 'document_title_parts', 'wmf_filter_wp_404title' );
 
 // Search page
-function theme_slug_filter_wp_searchtitle( $title_parts ) {
-    if ( is_search() ) {
-        $title_parts['title'] = sprintf( __( get_theme_mod( 'wmf_search_results_copy', __( 'Search results for %s', 'shiro-admin' ) ), 'shiro' ), get_search_query() );
-   }
+function wmf_filter_wp_searchtitle( $title_parts ) {
+	if ( is_search() ) {
+		$title_parts['title'] = sprintf( __( get_theme_mod( 'wmf_search_results_copy', __( 'Search results for %s', 'shiro-admin' ) ), 'shiro' ), get_search_query() );
+	}
 
-    return $title_parts;
+	return $title_parts;
 }
 
 // Hook into document_title_parts
-add_filter( 'document_title_parts', 'theme_slug_filter_wp_searchtitle' );
+add_filter( 'document_title_parts', 'wmf_filter_wp_searchtitle' );
 
 // Rewrite URL for roles to not require /news/ prefix
 add_rewrite_rule( '^role/(.+?)$', 'index.php?role=$matches[1]', 'top' );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -61,7 +61,7 @@
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="prefixes" type="array" value="wmf,rkv"/>
+			<property name="prefixes" type="array" value="wmf,shiro"/>
 		</properties>
 	</rule>
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -37,9 +37,12 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Internal.NoCodeFound"/>
+		<!-- We prefer short arrays. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<!-- Do not require = and => alignment. -->
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning"/>
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.IncorrectWarning"/>
 		<!-- Talk like yoda, you should not. -->
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<!-- Permit single-line PHP statements. -->
@@ -47,6 +50,7 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen"/>
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen"/>
 		<!--
 			The following rules are ones we DO recommend. They are omitted for now
 			to speed up the process of getting to basic compliance with more critical
@@ -54,6 +58,7 @@
 		-->
 		<exclude name="Generic.ControlStructures.InlineControlStructure.NotAllowed"/>
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidVariableName.StringNotSnakeCase">
 		<!-- Block attributes use JS-style naming patterns. -->

--- a/template-parts/header/page-single.php
+++ b/template-parts/header/page-single.php
@@ -9,12 +9,21 @@ $page_header_data = $args;
 
 $h4_link      = ! empty( $page_header_data['h4_link'] ) ? $page_header_data['h4_link'] : '';
 $h4_title     = ! empty( $page_header_data['h4_title'] ) ? $page_header_data['h4_title'] : '';
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $title        = ! empty( $page_header_data['h1_title'] ) ? $page_header_data['h1_title'] : '';
 $meta         = ! empty( $page_header_data['page_meta'] ) ? $page_header_data['page_meta'] : '';
 $allowed_tags = [
 	'span' => [ 'class' => [] ],
-	'time' => [ 'datetime' => [], 'itemprop' => [] ],
-	'a'    => [ 'href' => [], 'class' => [], 'title' => [], 'rel' => [] ],
+	'time' => [
+		'datetime' => [],
+		'itemprop' => [],
+	],
+	'a'    => [
+		'href' => [],
+		'class' => [],
+		'title' => [],
+		'rel' => [],
+	],
 ];
 ?>
 
@@ -34,7 +43,7 @@ $allowed_tags = [
 
 		<div class="mw-784">
 			<?php if ( ! empty( $title ) ) : ?>
-				<h1><?php echo wp_kses( $title, array( 'span' => array( 'class' ) ) ); ?></h1>
+				<h1><?php echo wp_kses( $title, [ 'span' => [ 'class' ] ] ); ?></h1>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $meta ) ) : ?>
@@ -43,10 +52,13 @@ $allowed_tags = [
 				</div>
 			<?php endif; ?>
 
-			<?php echo \WMF\Editor\Blocks\ShareArticle\render_block( array(
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo \WMF\Editor\Blocks\ShareArticle\render_block( [
 				'enableTwitter'  => true,
 				'enableFacebook' => true,
-			) ); ?>
+			] );
+			?>
 		</div>
 	</div>
 </div>

--- a/template-parts/header/page-single.php
+++ b/template-parts/header/page-single.php
@@ -9,7 +9,6 @@ $page_header_data = $args;
 
 $h4_link      = ! empty( $page_header_data['h4_link'] ) ? $page_header_data['h4_link'] : '';
 $h4_title     = ! empty( $page_header_data['h4_title'] ) ? $page_header_data['h4_title'] : '';
-// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $title        = ! empty( $page_header_data['h1_title'] ) ? $page_header_data['h1_title'] : '';
 $meta         = ! empty( $page_header_data['page_meta'] ) ? $page_header_data['page_meta'] : '';
 $allowed_tags = [

--- a/template-parts/modules/cards/card-horizontal.php
+++ b/template-parts/modules/cards/card-horizontal.php
@@ -77,9 +77,9 @@ $class      = $card_data['class'] ?? 'blog-post';
 		</div>
 
 		<a href="<?php echo esc_url( $link ); ?>"
-		   class="blog-post__read-more"
-		   aria-label="<?php /* translators: 1. the post title. */
-		   esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
+			class="blog-post__read-more"
+			aria-label="<?php /* translators: 1. the post title. */
+			esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
 			<?php esc_html_e( 'Read more', 'shiro' ); ?>
 		</a>
 	</div>

--- a/template-parts/modules/cards/card-horizontal.php
+++ b/template-parts/modules/cards/card-horizontal.php
@@ -49,10 +49,10 @@ $class      = $card_data['class'] ?? 'blog-post';
 		<?php if ( ! empty( $categories ) ) : ?>
 			<div class="blog-post__categories">
 				<?php
-					foreach ( $categories as $category ) {
-						printf( '<a class="blog-post__category-link" href="%1$s">%2$s</a> ', esc_url( get_category_link( $category->term_id ) ), esc_html( $category->name ) );
-					}
-					?>
+				foreach ( $categories as $category ) {
+					printf( '<a class="blog-post__category-link" href="%1$s">%2$s</a> ', esc_url( get_category_link( $category->term_id ) ), esc_html( $category->name ) );
+				}
+				?>
 			</div>
 		<?php endif; ?>
 
@@ -78,8 +78,9 @@ $class      = $card_data['class'] ?? 'blog-post';
 
 		<a href="<?php echo esc_url( $link ); ?>"
 			class="blog-post__read-more"
-			aria-label="<?php /* translators: 1. the post title. */
-			esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
+			aria-label="<?php
+			/* translators: 1. the post title. */
+			echo esc_attr( sprintf( __( 'Read more about %s', 'shiro' ), $title ) ); ?>">
 			<?php esc_html_e( 'Read more', 'shiro' ); ?>
 		</a>
 	</div>

--- a/template-parts/modules/cards/card-vertical.php
+++ b/template-parts/modules/cards/card-vertical.php
@@ -71,9 +71,9 @@ $image_size = true === $sidebar ? 'image_4x5_large' : 'image_4x3_large';
 			</div>
 
 			<a href="<?php echo esc_url( $link ); ?>"
-			   class="arrow-link"
-			   aria-label="<?php /* translators: 1. the post title. */
-			   esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
+				class="arrow-link"
+				aria-label="<?php /* translators: 1. the post title. */
+				esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
 				<?php esc_html_e( 'Read more', 'shiro' ); ?>
 			</a>
 		</div>

--- a/template-parts/modules/cards/card-vertical.php
+++ b/template-parts/modules/cards/card-vertical.php
@@ -72,8 +72,9 @@ $image_size = true === $sidebar ? 'image_4x5_large' : 'image_4x3_large';
 
 			<a href="<?php echo esc_url( $link ); ?>"
 				class="arrow-link"
-				aria-label="<?php /* translators: 1. the post title. */
-				esc_html_e( sprintf( 'Read more about %s', $title ), 'shiro' ); ?>">
+				aria-label="<?php
+				/* translators: 1. the post title. */
+				echo esc_attr( sprintf( __( 'Read more about %s', 'shiro' ), $title ) ); ?>">
 				<?php esc_html_e( 'Read more', 'shiro' ); ?>
 			</a>
 		</div>

--- a/template-parts/modules/featured/posts.php
+++ b/template-parts/modules/featured/posts.php
@@ -29,6 +29,7 @@ if ( empty( $featured_posts ) ) {
 			'post_status'    => 'publish',
 			'posts_per_page' => 2,
 			'no_found_rows'  => true,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(
 				array(
 					'key'     => 'featured_on',
@@ -37,7 +38,7 @@ if ( empty( $featured_posts ) ) {
 				),
 			),
 		)
-	); // WPCS: slow query ok.
+	);
 	wp_cache_add( $cache_key, $featured_posts );
 }
 

--- a/template-parts/modules/list/item.php
+++ b/template-parts/modules/list/item.php
@@ -15,7 +15,7 @@ $title       = $template_data['title'];
 $image       = ! empty( $template_data['image'] ) ? $template_data['image'] : '';
 $subhead     = ! empty( $template_data['subhead'] ) ? $template_data['subhead'] : '';
 $description = ! empty( $template_data['description'] ) ? $template_data['description'] : '';
-$link        = ! empty( $template_data['link'] ) ? $template_data['link'] : '';
+$item_link   = ! empty( $template_data['link'] ) ? $template_data['link'] : '';
 
 
 ?>
@@ -30,13 +30,13 @@ $link        = ! empty( $template_data['link'] ) ? $template_data['link'] : '';
 		<?php if ( ! empty( $title ) ) : ?>
 		<h3 class="h2 link-external">
 
-			<?php if ( ! empty( $link ) ) : ?>
-			<a href="<?php echo esc_url( $link ); ?>">
+			<?php if ( ! empty( $item_link ) ) : ?>
+			<a href="<?php echo esc_url( $item_link ); ?>">
 			<?php endif; ?>
 
 			<?php echo esc_html( $title ); ?>
 
-			<?php if ( ! empty( $link ) ) : ?>
+			<?php if ( ! empty( $item_link ) ) : ?>
 				<?php
 				if ( ! empty( $template_data['offsite'] ) ) {
 					wmf_show_icon( 'open', 'external-link-icon' );

--- a/template-parts/modules/related/posts.php
+++ b/template-parts/modules/related/posts.php
@@ -25,21 +25,25 @@ $rand_translation_title = wmf_get_random_translation( 'wmf_related_posts_title' 
 
 <div class="block-area">
 	<div class="wysiwyg mw-980">
-		<?php /** This uses the structure & styles of the double heading, but can't
-		 * use render_blocks() directly because the double-heading block
-		 * structures its data very differently.
-		 */ ?>
+		<?php
+		/*
+		This uses the structure & styles of the double heading, but can't
+		use render_blocks() directly because the double-heading block
+		structures its data very differently.
+		*/
+		?>
 		<div class="double-heading">
 			<?php if ( ! empty( $title ) ) : ?>
 				<p class="double-heading__secondary is-style-h5">
-					<span><?php echo esc_html( $title ) ?></span>
+					<span><?php echo esc_html( $title ); ?></span>
 				</p>
 			<?php endif; ?>
 			<h2 class="double-heading__primary is-style-h3">
-				<?php echo esc_html( $description ) ?>
+				<?php echo esc_html( $description ); ?>
 				<?php if ( ! empty( $authorlink ) ) : ?>
-					<span class="authorlink"><a
-								href="/news/author/<?php echo esc_attr( $authorlink ); ?>">View all</a></span>
+					<span class="authorlink">
+						<a href="/news/author/<?php echo esc_attr( $authorlink ); ?>">View all</a>
+					</span>
 				<?php endif; ?>
 			</h2>
 		</div>


### PR DESCRIPTION
Now that we have PHP linting wired up, some PRs will trigger an onslaught of PHPCS errors. This PR preemptively addresses  errors in the code touched by #4 so that the feature PR can be addressed independently.

It also resolves a global issue with #7 where outdated versions of the WP standards were being used which could cause fatal errors when running `phpcs` in the GitHub action.