### PR TITLE
Introduce a Develop branch and release-develop build

### DIFF
--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -53,5 +53,5 @@ runs:
       shell: bash
       run: |
         git add -f ${{ inputs.built_asset_paths }}
-        git commit --amend -m "Build to 'release' from ${{ inputs.source_branch }}#$( git rev-parse --short ${{ inputs.source_branch }} )"
+        git commit --amend -m "Build to '${{ inputs.release_branch }}' from ${{ inputs.source_branch }}#$( git rev-parse --short ${{ inputs.source_branch }} )"
         git push origin ${{ inputs.release_branch }}:${{ inputs.release_branch }}

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: "Update release-develop branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Merge and build
+        uses: ./.github/actions/build-to-release-branch
+        with:
+          source_branch: develop
+          release_branch: release-develop
+          built_asset_paths: ./*.css package-lock.json map assets/dist
+          build_script: |
+            npm ci
+            npm run build

--- a/README.md
+++ b/README.md
@@ -7,11 +7,27 @@ Folder Structure
 ---------------
 The basic folder structure keeps things fairly simple and organized by type.
 
-The `assets` folder contains front-end files in the `src` sub-directory. Any files that need to be concatenated are output into `dist` and files are enqueued by the theme from there.
+The `assets` folder contains front-end files in the `src` sub-directory. Any files that need to be generated or built from source are output into `dist`, and files are enqueued by the theme from that directory.
 
 The `inc` folder contains all PHP files that aren't required in the root directory by WordPress.
 
 The `template-parts` folder contains template parts used by larger templates in the root directory.
+
+Deploy Process
+---------------
+The release and release-develop versions of the Shiro theme are built using [GitHub Actions](https://github.com/features/actions). Any time a pull request is merged into the `main` or `develop` branches, that code is built and pushed to the corresponding `release` and `release-develop` branches. **You should not commit to the release branches directly,** nor submit pull requests against them.
+
+Development workflow:
+
+- Implement a feature or bugfix in a feature branch created off of `main`
+- Submit a pull request from that feature branch back into `main`, and get code review
+- Merge the feature branch into `develop` manually.
+  - The `release-develop` branch will be automatically rebuilt
+- Update the preproduction or development environment for your project to reference the newest built version of the `release-develop` branch, to deploy and test the theme PR.
+- Once approved, merge the pull request into `main`
+  - The `release` branch will be automatically rebuilt
+- Update the production branch in your project repository to reference the newest built version of the `release` branch, to deploy the change to production.
+
 
 Build Process
 ---------------
@@ -43,11 +59,13 @@ CSS should follow the BEM naming convention and files should be clearly commente
 
 JS
 ---------------
-JS should follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/). In addition, please use [JSDoc](http://eslint.org/docs/rules/require-jsdoc) when commenting on functions.
+JS should follow the project linting standards, which are based on the [WordPress core coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/) and [Human Made coding standards]([https://](https://www.npmjs.com/package/@humanmade/eslint-config)). In addition, please use [JSDoc](http://eslint.org/docs/rules/require-jsdoc) to document functions.
+
+Due to evolving JavaScript best practices over the lifecycle of this project, different pieces of JS code are held to slightly different coding standards. ESLint is configured in [`.eslintrc`](.eslintrc).
 
 PHP
 ---------------
-PHP should follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/). PHP Codesniffer is configured in `wp-content/.phpcs.xml.dist`.
+PHP should follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/). PHP Codesniffer is configured in [`phpcs.xml`](phpcs.xml).
 
 Icons
 ---------------


### PR DESCRIPTION
To be able to test preproduction changes without merging to `main`, this PR introduces a separate `develop` and corresponding `release-develop` branch.