### PR TITLE
Address PHP warnings observed in VIP logs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "scripts": {
         "phpcs": "phpcs .",
-        "phpcs:changed": "phpcs $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head main) | grep '\\.php')"
+        "phpcs:changed": "phpcs $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head main) | grep '\\.php')",
+        "phpcbf:changed": "phpcbf $(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base head main) | grep '\\.php')"
     }
 }

--- a/inc/editor/blocks/double-heading.php
+++ b/inc/editor/blocks/double-heading.php
@@ -40,7 +40,7 @@ function render_block( $attributes ) {
 	$customClass = $attributes['className'] ?? false;
 	$className = $customClass ? "double-heading $customClass" : "double-heading";
 
-	foreach ( $attributes['secondaryHeadings'] as $heading ) {
+	foreach ( ( $attributes['secondaryHeadings'] ?? [] ) as $heading ) {
 		if ( $site_language['shortname'] ?? null === ( $heading['lang'] ?? '' ) ) {
 			$site_language_heading = $heading;
 			continue;

--- a/inc/editor/blocks/double-heading.php
+++ b/inc/editor/blocks/double-heading.php
@@ -38,7 +38,7 @@ function render_block( $attributes ) {
 	$translated_headings = [];
 	$site_language_heading = null;
 	$customClass = $attributes['className'] ?? false;
-	$className = $customClass ? "double-heading $customClass" : "double-heading";
+	$className = $customClass ? "double-heading $customClass" : 'double-heading';
 
 	foreach ( ( $attributes['secondaryHeadings'] ?? [] ) as $heading ) {
 		if ( $site_language['shortname'] ?? null === ( $heading['lang'] ?? '' ) ) {
@@ -62,28 +62,28 @@ function render_block( $attributes ) {
 		$random_key         = array_rand( $translated_headings );
 		$translated_heading = $translated_headings[ $random_key ];
 	}
-	$primary_heading    = $attributes[ 'primaryHeading'] ?? null;
+	$primary_heading    = $attributes['primaryHeading'] ?? null;
 
 	ob_start()
 	?>
-		<div class="<?php echo esc_attr( $className ) ?>">
+		<div class="<?php echo esc_attr( $className ); ?>">
 			<?php if ( ! empty( $site_language_heading ) ) : ?>
 				<p class="double-heading__secondary is-style-h5">
-					<span><?php echo esc_html( $site_language_heading['text'] ) ?></span>
+					<span><?php echo esc_html( $site_language_heading['text'] ); ?></span>
 					<?php if ( ! empty( $translated_heading ) ) : ?>
 						—
 						<span
 							class="<?php echo esc_attr( $translated_heading['className'] ); ?>"
-							lang="<?php echo esc_attr( $translated_heading['lang'] ?? '' ) ?>"
+							lang="<?php echo esc_attr( $translated_heading['lang'] ?? '' ); ?>"
 						>
-							<?php echo esc_html( $translated_heading['text'] ) ?>
+							<?php echo esc_html( $translated_heading['text'] ); ?>
 						</span>
 					<?php endif; ?>
 				</p>
 			<?php endif; ?>
 			<?php if ( $primary_heading ) : ?>
 				<h2 class="double-heading__primary is-style-h3">
-					<?php echo esc_html( $primary_heading ) ?>
+					<?php echo esc_html( $primary_heading ); ?>
 				</h2>
 			<?php endif; ?>
 		</div>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,9 +60,15 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
 		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited"/>
 	</rule>
+	<!-- Block attributes use JS-style naming patterns. -->
 	<rule ref="WordPress.NamingConventions.ValidVariableName.StringNotSnakeCase">
-		<!-- Block attributes use JS-style naming patterns. -->
-		<exclude-pattern>inc/editor/blocks/</exclude-pattern>
+		<exclude-pattern>inc/editor/blocks</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase">
+		<exclude-pattern>inc/editor/blocks</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+		<exclude-pattern>inc/editor/blocks</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/sidebar-list.php
+++ b/sidebar-list.php
@@ -10,7 +10,7 @@
 // $args is data passed into the template, also we provide fallbacks in case they don't exist.
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $nested        = $args['nested'] ?? false;
-$template_args = is_array( $args['template_args'] ) ? $args['template_args'] : get_post_meta( get_the_ID(), 'list', true );
+$template_args = is_array( $args['template_args'] ?? false ) ? $args['template_args'] : get_post_meta( get_the_ID(), 'list', true );
 // phpcs:enable
 
 if ( empty( $template_args ) ) {
@@ -59,7 +59,7 @@ if ( empty( $template_args ) ) {
 	<?php
 	foreach ( $template_args as $i => $list_section ) :
 		$item_text = $list_section['title'] ?? $list_section['name'];
-		$item_link = $list_section['slug'] ? '#' . $list_section['slug'] : '#section-' . ( $i + 1 );
+		$item_link = ( $list_section['slug'] ?? false ) ? '#' . $list_section['slug'] : '#section-' . ( $i + 1 );
 		if ( empty( $item_text ) ) {
 			continue;
 		}

--- a/sidebar-list.php
+++ b/sidebar-list.php
@@ -32,7 +32,7 @@ if ( empty( $template_args ) ) {
 	data-visible="false"
 >
 	<h2 class="toc__title screen-reader-text">
-		<?php esc_html_e( 'Table of Contents', 'shiro' ) ?>
+		<?php esc_html_e( 'Table of Contents', 'shiro' ); ?>
 	</h2>
 	<button
 		aria-expanded="false"
@@ -40,7 +40,7 @@ if ( empty( $template_args ) ) {
 		hidden
 	>
 		<span class="btn-label-a11y">
-			<?php esc_html_e( 'Navigate within this page.', 'shiro' ) ?>
+			<?php esc_html_e( 'Navigate within this page.', 'shiro' ); ?>
 		</span>
 		<span class="btn-label-active-item">
 			<?php

--- a/template-parts/profiles/role-item.php
+++ b/template-parts/profiles/role-item.php
@@ -39,10 +39,10 @@ if ( $profile_data['role'] ?? false ) {
 	<div class="<?php echo esc_attr( $profile_class ); ?>">
 <?php endif;
 
-	if ( $profile_img ) :
-		echo wp_kses_post( $profile_img );
+if ( $profile_img ) :
+	echo wp_kses_post( $profile_img );
 	else :
-	?>
+		?>
 		<span class="role__staff-list__item__photo"></span>
 	<?php endif; ?>
 

--- a/template-parts/profiles/role-item.php
+++ b/template-parts/profiles/role-item.php
@@ -28,7 +28,7 @@ $profile_img = get_the_post_thumbnail(
 );
 
 $profile_class = 'role__staff-list__item';
-if ( $profile_data['role'] ) {
+if ( $profile_data['role'] ?? false ) {
 	$profile_class .= ' role__staff-list__item--' . $profile_data['role'];
 }
 ?>


### PR DESCRIPTION
Several PHP warnings have been reported in the deployed environment, which began to show up after the upgrade to PHP 8 (at which point the undefined array key became a warning). This PR addresses several pervasive warnings, and fixing them will make it easier to recognize true issues in the application health logs.