### PR TITLE
530: PHPCS changes for PR #16

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -132,6 +132,7 @@ function wmf_get_role_posts( $term_id ) {
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 			'posts_per_page' => 100,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'tax_query'      => array(
 				array(
 					'taxonomy'         => 'role',
@@ -141,7 +142,7 @@ function wmf_get_role_posts( $term_id ) {
 				),
 			),
 		)
-	); // WPCS: slow query ok.
+	);
 
 	$post_list     = wmf_sort_by_last_name( $posts->posts );
 	$featured_list = array();
@@ -255,6 +256,7 @@ function wmf_get_related_profiles( $profile_id ) {
 				'no_found_rows'  => true,
 				'fields'         => 'ids',
 				'post_type'      => 'profile',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				'tax_query'      => array(
 					array(
 						'taxonomy' => 'role',
@@ -262,7 +264,7 @@ function wmf_get_related_profiles( $profile_id ) {
 					),
 				),
 			)
-		); // WPCS: slow query ok.
+		);
 
 		$profile_list = $profiles_query->posts;
 		wp_cache_add( $cache_key, $profile_list );
@@ -310,6 +312,7 @@ function wmf_get_related_posts( $post_id ) {
 				'no_found_rows'  => true,
 				'post_type'      => 'post',
 				'ignore_sticky'  => true,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				'tax_query'      => array(
 					array(
 						'taxonomy' => 'post_tag',
@@ -317,7 +320,7 @@ function wmf_get_related_posts( $post_id ) {
 					),
 				),
 			)
-		); // WPCS: Slow query ok.
+		);
 
 		$post_list = $posts_query->posts;
 		foreach ( $post_list as $i => $post ) {
@@ -364,7 +367,7 @@ function wmf_get_recent_author_posts( $author_id ) {
 					'ignore_sticky'  => true,
 					'author_name'    => $post->post_name,
 				)
-			); // WPCS: Slow query ok.
+			);
 
 			$post_list = $posts_query->posts;
 			wp_cache_add( $cache_key, $post_list );
@@ -529,7 +532,6 @@ function wmf_sort_by_last_name( $posts ) {
 /**
  * Register custom RSS templates.
  */
-add_action( 'after_setup_theme', 'wmf_rss_templates' );
 function wmf_rss_templates() {
 	foreach ( array( 'offset1', 'images' ) as $name ) {
 		add_feed( $name,
@@ -539,9 +541,12 @@ function wmf_rss_templates() {
 		);
 	}
 }
+add_action( 'after_setup_theme', 'wmf_rss_templates' );
 
 /**
  * Setup offset for offset1 RSS feed.
+ *
+ * @param \WP_Query $query Query being executed.
  */
 function wpsites_exclude_latest_post( $query ) {
 	if ( $query->is_main_query() && $query->is_feed( 'offset1' ) ) {
@@ -667,7 +672,7 @@ function wmf_get_page_stories() {
 /**
  * Get the uri for an SVG in the theme, by name.
  *
- * @param string $name
+ * @param string $name SVG name.
  *
  * @return string
  */
@@ -684,7 +689,7 @@ function wmf_get_svg_uri( string $name ): string {
  * asset processed by webpack. This function takes that into account, and
  * will return a hashed asset if one exists.
  *
- * @param string $name
+ * @param string $name Asset name.
  *
  * @return string
  */
@@ -702,7 +707,7 @@ function wmf_get_gulp_asset_uri( string $name ): string {
 /**
  * Echo & wrap a piece of text with an href if the possible URL is set.
  *
- * @param string $text The text to wrap
+ * @param string $text The text to wrap.
  * @param string $possible_url The URL to put in the href of the link.
  */
 function wmf_shiro_echo_wrap_with_link( $text, $possible_url = '' ) {
@@ -718,7 +723,7 @@ function wmf_shiro_echo_wrap_with_link( $text, $possible_url = '' ) {
 		</a>
 		<?php if ( $creative_commons ) : ?>
 		<a href="https://commons.wikimedia.org/" class="commons-tooltip-wrapper" aria-describedby="commons-tooltip" tabindex="0">
-			   <span id="commons-tooltip" role="tooltip"><?php esc_html_e( 'File provided by Wikimedia Commons', 'shiro' ); ?></span>
+			<span id="commons-tooltip" role="tooltip"><?php esc_html_e( 'File provided by Wikimedia Commons', 'shiro' ); ?></span>
 		</a>
 		<?php endif; ?>
 	</div>
@@ -731,8 +736,8 @@ function wmf_shiro_echo_wrap_with_link( $text, $possible_url = '' ) {
  *
  * @see https://kybernaut.cz/en/clanky/check-for-has_block-inside-reusable-blocks/
  *
- * @param                  $block_name
- * @param int|WP_Post|null $post
+ * @param string           $block_name Name of block.
+ * @param int|WP_Post|null $post       Post to check for block.
  *
  * @return bool
  */
@@ -756,9 +761,9 @@ function wmf_enhanced_has_block( $block_name, $post = null ): bool {
  *
  * @see https://kybernaut.cz/en/clanky/check-for-has_block-inside-reusable-blocks/
  *
- * @param                  $blocks
- * @param                  $block_name
- * @param int|WP_Post|null $post
+ * @param array            $blocks     InnerBlocks tree.
+ * @param string           $block_name Name of block.
+ * @param int|WP_Post|null $post       Post to check for block.
  *
  * @return bool
  */
@@ -780,7 +785,7 @@ function wmf_search_reusable_blocks_within_innerblocks( $blocks, $block_name, $p
  *
  * Returns the id of the reusable block if found; 0 otherwise.
  *
- * @param string $module
+ * @param string $module Block module.
  *
  * @return int
  */
@@ -797,8 +802,8 @@ function wmf_get_reusable_block_module_id( string $module ): int {
 	$id = get_theme_mod( $available_blocks[ $module ] );
 
 	$valid = is_numeric( $id )
-			 && $id > 0
-			 && get_post_type( $id ) === 'wp_block';
+		&& $id > 0
+		&& get_post_type( $id ) === 'wp_block';
 
 	return $valid ? (int) $id : 0;
 }
@@ -808,7 +813,7 @@ function wmf_get_reusable_block_module_id( string $module ): int {
  *
  * Returns null if none found.
  *
- * @param string $module
+ * @param string $module Block module.
  *
  * @return null|WP_Post
  */
@@ -823,7 +828,7 @@ function wmf_get_reusable_block_module( string $module ) {
  *
  * Returns an empty string if block does not exist or cannot be found.
  *
- * @param string $module
+ * @param string $module Block module.
  *
  * @return string
  */

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -548,12 +548,12 @@ add_action( 'after_setup_theme', 'wmf_rss_templates' );
  *
  * @param \WP_Query $query Query being executed.
  */
-function wpsites_exclude_latest_post( $query ) {
+function wmf_offset1_exclude_latest_post( $query ) {
 	if ( $query->is_main_query() && $query->is_feed( 'offset1' ) ) {
 		$query->set( 'offset', '1' );
 	}
 }
-add_action( 'pre_get_posts', 'wpsites_exclude_latest_post', 1 );
+add_action( 'pre_get_posts', 'wmf_offset1_exclude_latest_post', 1 );
 
 /**
  * Check whether the current post is part of a new-style transparency report

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -30,7 +30,7 @@ add_filter( 'body_class', 'wmf_body_classes' );
  * @return string Container classes to add.
  */
 function wmf_get_header_container_class() {
-	if ( is_front_page() && !has_blocks() ) {
+	if ( is_front_page() && ! has_blocks() ) {
 		$class = 'header-home';
 	} else {
 		$class = 'header-default';
@@ -306,7 +306,7 @@ function wmf_get_related_posts( $post_id ) {
 		$posts_query = new WP_Query(
 			array(
 				'posts_per_page' => 3,
-                'orderby'        => 'date',
+				'orderby'        => 'date',
 				'no_found_rows'  => true,
 				'post_type'      => 'post',
 				'ignore_sticky'  => true,
@@ -357,7 +357,7 @@ function wmf_get_recent_author_posts( $author_id ) {
 		if ( ! empty( $post ) ) {
 			$posts_query = new WP_Query(
 				array(
-                    'orderby'        => 'date',
+					'orderby'        => 'date',
 					'posts_per_page' => 2,
 					'no_found_rows'  => true,
 					'post_type'      => 'post',
@@ -397,7 +397,7 @@ function wmf_get_author_link( $author_id ) {
 		$post = get_post( $author_id );
 	}
 
-    $author_link = $post->post_name;
+	$author_link = $post->post_name;
 
 	return $author_link;
 }
@@ -530,26 +530,23 @@ function wmf_sort_by_last_name( $posts ) {
  * Register custom RSS templates.
  */
 add_action( 'after_setup_theme', 'wmf_rss_templates' );
-function wmf_rss_templates()
-{
-    foreach( array( 'offset1', 'images' ) as $name )
-    {
-        add_feed( $name,
-            function() use ( $name )
-            {
-                get_template_part( 'feed', $name );
-            }
-        );
-    }
+function wmf_rss_templates() {
+	foreach ( array( 'offset1', 'images' ) as $name ) {
+		add_feed( $name,
+			function() use ( $name ) {
+				get_template_part( 'feed', $name );
+			}
+		);
+	}
 }
 
 /**
  * Setup offset for offset1 RSS feed.
  */
 function wpsites_exclude_latest_post( $query ) {
-if ( $query->is_main_query() && $query->is_feed( 'offset1' )) {
-    $query->set( 'offset', '1' );
-    }
+	if ( $query->is_main_query() && $query->is_feed( 'offset1' ) ) {
+		$query->set( 'offset', '1' );
+	}
 }
 add_action( 'pre_get_posts', 'wpsites_exclude_latest_post', 1 );
 
@@ -674,11 +671,10 @@ function wmf_get_page_stories() {
  *
  * @return string
  */
-function wmf_get_svg_uri( string $name ): string
-{
-	$name = str_replace( '.svg', '', $name);
+function wmf_get_svg_uri( string $name ): string {
+	$name = str_replace( '.svg', '', $name );
 	$uri = get_template_directory_uri() . '/assets/src/svg/' . $name . '.svg';
-	return esc_url($uri);
+	return esc_url( $uri );
 }
 
 /**
@@ -695,8 +691,8 @@ function wmf_get_svg_uri( string $name ): string
 function wmf_get_gulp_asset_uri( string $name ): string {
 	$dist_path = get_template_directory_uri() . '/assets/dist/';
 	$manifest  = load_asset_manifest( get_active_manifest( [
-			get_template_directory() . '/assets/dist/rev-manifest.json',
-		] ) ) ?? [];
+		get_template_directory() . '/assets/dist/rev-manifest.json',
+	] ) ) ?? [];
 
 	$resolved_name = $manifest[ $name ] ?? $name;
 
@@ -715,18 +711,18 @@ function wmf_shiro_echo_wrap_with_link( $text, $possible_url = '' ) {
 	else :
 		$host = parse_url( $possible_url, PHP_URL_HOST );
 		$creative_commons = false !== strpos( $host, 'commons.wikimedia.org' );
-	?>
+		?>
 	<div>
 		<a href="<?php echo esc_url( $possible_url ); ?>" target="_blank" rel="noopener noreferrer">
 			<?php echo esc_html( $text ); ?>
 		</a>
-		<?php if ( $creative_commons ): ?>
+		<?php if ( $creative_commons ) : ?>
 		<a href="https://commons.wikimedia.org/" class="commons-tooltip-wrapper" aria-describedby="commons-tooltip" tabindex="0">
-   			<span id="commons-tooltip" role="tooltip"><?php esc_html_e('File provided by Wikimedia Commons', 'shiro'); ?></span>
+			   <span id="commons-tooltip" role="tooltip"><?php esc_html_e( 'File provided by Wikimedia Commons', 'shiro' ); ?></span>
 		</a>
 		<?php endif; ?>
 	</div>
-	<?php
+		<?php
 	endif;
 }
 
@@ -771,7 +767,7 @@ function wmf_search_reusable_blocks_within_innerblocks( $blocks, $block_name, $p
 		if ( isset( $block['innerBlocks'] ) && ! empty( $block['innerBlocks'] ) ) {
 			wmf_search_reusable_blocks_within_innerblocks( $block['innerBlocks'], $block_name, $post );
 		} elseif ( $block['blockName'] === 'core/block' && ! empty( $block['attrs']['ref'] ) && \has_block( $block_name,
-				$block['attrs']['ref'] ) ) {
+		$block['attrs']['ref'] ) ) {
 			return true;
 		}
 	}
@@ -801,8 +797,8 @@ function wmf_get_reusable_block_module_id( string $module ): int {
 	$id = get_theme_mod( $available_blocks[ $module ] );
 
 	$valid = is_numeric( $id )
-	         && $id > 0
-	         && get_post_type( $id ) === 'wp_block';
+			 && $id > 0
+			 && get_post_type( $id ) === 'wp_block';
 
 	return $valid ? (int) $id : 0;
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -661,6 +661,7 @@ function wmf_get_page_stories() {
 			'post_type'        => 'story',
 			'post_status'      => 'publish',
 			'post__in'         => $story_ids,
+			// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 			'posts_per_page'   => count( $story_ids ),
 			'suppress_filters' => false,
 		)

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -714,7 +714,7 @@ function wmf_shiro_echo_wrap_with_link( $text, $possible_url = '' ) {
 	if ( empty( $possible_url ) ) :
 		echo esc_html( $text );
 	else :
-		$host = parse_url( $possible_url, PHP_URL_HOST );
+		$host = wp_parse_url( $possible_url, PHP_URL_HOST );
 		$creative_commons = false !== strpos( $host, 'commons.wikimedia.org' );
 		?>
 	<div>

--- a/template-parts/modules/images/credit.php
+++ b/template-parts/modules/images/credit.php
@@ -24,26 +24,26 @@ $author      = ! empty( $credit_info['author'] ) ? $credit_info['author'] : '';
 $license     = ! empty( $credit_info['license'] ) ? $credit_info['license'] : '';
 $url         = ! empty( $credit_info['url'] ) ? $credit_info['url'] : '';
 
-if ( is_int(stripos($license,'Public domain') ) ) {
+if ( is_int( stripos( $license, 'Public domain' ) ) ) {
 	$license_url = 'https://en.wikipedia.org/wiki/Public_domain';
-} elseif ( is_int(stripos($license,'GFDL') ) && is_int(stripos($license,'1.2') )  ) {
-    $license_url = 'https://commons.wikimedia.org/wiki/Commons:GNU_Free_Documentation_License,_version_1.2';
-} elseif ( is_int(stripos($license,'CC0') ) ) {
-    $license_url = 'https://creativecommons.org/publicdomain/zero/1.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && is_int(stripos($license,'SA') ) && is_int(stripos($license,'4.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by-sa/4.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && is_int(stripos($license,'SA') ) && is_int(stripos($license,'3.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by-sa/3.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && is_int(stripos($license,'SA') ) && is_int(stripos($license,'2.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by-sa/2.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && ! is_int(stripos($license,'SA') ) && is_int(stripos($license,'4.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by/4.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && ! is_int(stripos($license,'SA') ) && is_int(stripos($license,'3.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by/3.0/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && ! is_int(stripos($license,'SA') ) && is_int(stripos($license,'2.5') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by/2.5/';
-} elseif ( is_int(stripos($license,'CC') ) && is_int(stripos($license,'BY') ) && ! is_int(stripos($license,'SA') ) && is_int(stripos($license,'2.0') )  ) {
-    $license_url = 'https://creativecommons.org/licenses/by/2.0/';
+} elseif ( is_int( stripos( $license, 'GFDL' ) ) && is_int( stripos( $license, '1.2' ) ) ) {
+	$license_url = 'https://commons.wikimedia.org/wiki/Commons:GNU_Free_Documentation_License,_version_1.2';
+} elseif ( is_int( stripos( $license, 'CC0' ) ) ) {
+	$license_url = 'https://creativecommons.org/publicdomain/zero/1.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by-sa/4.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '3.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by-sa/3.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by-sa/2.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '4.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by/4.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '3.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by/3.0/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.5' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by/2.5/';
+} elseif ( is_int( stripos( $license, 'CC' ) ) && is_int( stripos( $license, 'BY' ) ) && ! is_int( stripos( $license, 'SA' ) ) && is_int( stripos( $license, '2.0' ) ) ) {
+	$license_url = 'https://creativecommons.org/licenses/by/2.0/';
 } else {
 	$license_url = ! empty( $credit_info['license_url'] ) ? $credit_info['license_url'] : '';
 }
@@ -51,7 +51,7 @@ if ( is_int(stripos($license,'Public domain') ) ) {
 
 <div class="attribution-item">
 	<div class="attribution-item__image">
-		<?php echo wp_get_attachment_image( $image_id, [63, 63] ); ?>
+		<?php echo wp_get_attachment_image( $image_id, [ 63, 63 ] ); ?>
 	</div>
 
 	<div class="attribution-item__content">


### PR DESCRIPTION
- Whitespace fixes (executed using `phpcbf` to auto-correct)
- Add comments for function parameters
- Use wp_parse_query instead of inconsistent parse_query
- Adjust ignore comments for query performance to match new PHPCS syntax
- Rename one function which was improperly namespaced