### PR TITLE
762: Do not add our own custom filter when we can use core's

### DIFF
--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -111,13 +111,7 @@ function filter_blocks( $allowed_block_types, $block_editor_context ) {
 		$blocks[] = 'shiro/report-landing-hero';
 	}
 
-	/**
-	 * Permit customization of the allowed block list.
-	 *
- * @param string[]                 $allowed_blocks       Array of block type slugs which should be allowed.
- * @param \WP_Block_Editor_Context $block_editor_context The current block editor context.
-	 */
-	return apply_filters( 'wmf_shiro_allowed_blocks', $blocks, $block_editor_context );
+	return $blocks;
 }
 
 /**


### PR DESCRIPTION
In retrospect, before this goes live, we should avoid introducing a new filter for specifying allowed blocks when we can simply add a higher-priority filter function on core's same `allowed_block_types_all` hook.