### PR TITLE
Fix language tax update when saving content in the block editor

### DIFF
--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -85,23 +85,21 @@ function wmf_get_and_maybe_create_current_language_term(): ?WP_Term {
  */
 function wmf_create_current_language_term(): ?WP_Term {
 
-	// When this function is called from the REST API, the admin taxonomy
-	// utilities may not be available. This fix ensures that the content
-	// language functionality works in the block editor.
-	if ( ! function_exists( 'wp_create_term' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
-	}
-
 	// Make sure that we always have the "main language" term.
 	$main_locale = wmf_get_current_content_language_term();
-	if ( ! is_a( $main_locale, WP_Term::class ) ) {
-		$result = wp_create_term( wmf_get_current_content_language_slug(), 'content-language' );
-		if ( is_wp_error( $result ) ) {
-			return null;
-		}
-		return get_term( $result['term_id'], 'content-language' );
+
+	if ( is_a( $main_locale, WP_Term::class ) ) {
+		return $main_locale;
 	}
-	return $main_locale;
+
+	// If the current language term doesn't exist, create it now and return it.
+	$created_term = wp_insert_term( wmf_get_current_content_language_slug(), 'content-language' );
+
+	if ( is_wp_error( $created_term ) ) {
+		return null;
+	}
+
+	return get_term( $created_term['term_id'] , 'content-language' );
 }
 
 /**

--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -74,10 +74,13 @@ function wmf_get_and_maybe_create_current_language_term(): ?WP_Term {
  * @return \WP_Term|null
  */
 function wmf_create_current_language_term(): ?WP_Term {
+
 	// When this function is called from the REST API, the admin taxonomy
 	// utilities may not be available. This fix ensures that the content
 	// language functionality works in the block editor.
-	require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+	if ( ! function_exists( 'wp_create_term' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+	}
 
 	// Make sure that we always have the "main language" term.
 	$main_locale = wmf_get_current_content_language_term();

--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -99,7 +99,7 @@ function wmf_create_current_language_term(): ?WP_Term {
 		return null;
 	}
 
-	return get_term( $created_term['term_id'] , 'content-language' );
+	return get_term( $created_term['term_id'], 'content-language' );
 }
 
 /**

--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -9,7 +9,7 @@
  */
 function wmf_register_content_language_taxonomy(): void {
 	$language_type_args = array(
-		'heirarchical' => false,
+		'hierarchical' => false,
 		'show_in_rest' => true,
 		'rewrite' => false,
 		'label' => __( 'Content Language', 'shiro-admin' ),
@@ -74,6 +74,11 @@ function wmf_get_and_maybe_create_current_language_term(): ?WP_Term {
  * @return \WP_Term|null
  */
 function wmf_create_current_language_term(): ?WP_Term {
+	// When this function is called from the REST API, the admin taxonomy
+	// utilities may not be available. This fix ensures that the content
+	// language functionality works in the block editor.
+	require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+
 	// Make sure that we always have the "main language" term.
 	$main_locale = wmf_get_current_content_language_term();
 	if ( ! is_a( $main_locale, WP_Term::class ) ) {


### PR DESCRIPTION
When creating content locally with the latest version of shiro theme, any attempts to update newly-created posts break with the following error:

    Fatal error: Uncaught Error: Call to undefined function wp_create_term()
    in /srv/www/wikimediafoundation/public_html/wp-content/themes/shiro/inc/taxonomy-content-language.php on line 80

This is happening because in the REST API endpoint hit to update content in the block editor, wp-admin/includes/taxonomy.php isn't loaded by default. This change ensures that this file is required whenever trying to update language taxonomy terms.