### PR TITLE
[hotfix] Fix eslint warning in collapsible-block js handler

### DIFF
--- a/assets/src/scripts/block-collapsible-text.js
+++ b/assets/src/scripts/block-collapsible-text.js
@@ -20,7 +20,7 @@ const toggleCollapsibleArea = ( { currentTarget } ) => {
  * @returns {HTMLElement[]} All toggle buttons on the current page.
  */
 const initializeCollapsibleTextBlocks = () => {
-	[ ...document.querySelectorAll( '.collapsible-text__toggle' ) ].forEach(
+	return [ ...document.querySelectorAll( '.collapsible-text__toggle' ) ].forEach(
 		button => button.addEventListener( 'click', toggleCollapsibleArea )
 	);
 };


### PR DESCRIPTION
This script is throwing warnings on every build. Adding an explicit return should fix it.