### PR TITLE
758 - Contrast link

### DIFF
--- a/assets/src/editor/blocks/card/index.js
+++ b/assets/src/editor/blocks/card/index.js
@@ -12,13 +12,15 @@ import { __ } from '@wordpress/i18n';
 import BlockIcon from '../../../svg/blocks/card.svg';
 import CallToActionPicker from '../../components/cta';
 import ImagePicker from '../../components/image-picker';
+import sharedStyles from '../../helpers/block-styles';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-export const name = 'shiro/card';
+export const name = 'shiro/card',
+	styles = sharedStyles;
 
 export const settings = {
 	apiVersion: 2,

--- a/assets/src/editor/blocks/card/index.js
+++ b/assets/src/editor/blocks/card/index.js
@@ -19,8 +19,8 @@ import sharedStyles from '../../helpers/block-styles';
  */
 import './style.scss';
 
-export const name = 'shiro/card',
-	styles = sharedStyles;
+export const name = 'shiro/card';
+export const styles = sharedStyles;
 
 export const settings = {
 	apiVersion: 2,

--- a/assets/src/sass/blocks/_card.scss
+++ b/assets/src/sass/blocks/_card.scss
@@ -1,5 +1,7 @@
 .content-card {
 	@include global-margin-bottom;
+	@include block-style-background-color;
+	@include block-style-text-color;
 
 	border: 1px solid $wmui-color-base80;
 	border-radius: 4px;
@@ -49,5 +51,19 @@
 		&::before {
 			@include absolute-full-cover();
 		}
+
+	}
+
+	&.is-style-base0,
+	&.is-style-blue50,
+	&.is-style-green,
+	&.is-style-red50,
+	&.is-style-red,
+	&.is-style-purple,
+	&.is-style-bright-blue {
+		.content-card__call-to-action  {
+			color: $wmui-color-base100;
+		}
 	}
 }
+

--- a/assets/src/sass/components/_group.scss
+++ b/assets/src/sass/components/_group.scss
@@ -12,7 +12,8 @@
 	&.has-red-50-background-color,
 	&.has-red-aaa-background-color  {
 		.wp-block-button.is-style-as-link .wp-block-button__link,
-		.wp-block-button.is-style-as-link .wp-block-button__link:hover {
+		.wp-block-button.is-style-as-link .wp-block-button__link:hover,
+		.wp-block-shiro-button.is-style-as-link:hover {
 			color: $wmui-color-base100;
 		}
 	}

--- a/assets/src/sass/components/_group.scss
+++ b/assets/src/sass/components/_group.scss
@@ -1,0 +1,19 @@
+.wp-block-group {
+	&.has-blue-background-color,
+	&.has-bright-blue-background-color,
+	&.has-blue-50-background-color,
+	&.has-blue-aaa-background-color,
+	&.has-dark-green-background-color,
+	&.has-orange-background-color,
+	&.has-green-aaa-background-color,
+	&.has-green-background-color,
+	&.has-purple-background-color,
+	&.has-red-background-color,
+	&.has-red-50-background-color,
+	&.has-red-aaa-background-color  {
+		.wp-block-button.is-style-as-link .wp-block-button__link,
+		.wp-block-button.is-style-as-link .wp-block-button__link:hover {
+			color: $wmui-color-base100;
+		}
+	}
+}

--- a/assets/src/sass/editor/_global.scss
+++ b/assets/src/sass/editor/_global.scss
@@ -81,3 +81,23 @@ body {
 		font-weight: 700;
 	}
 }
+
+.wp-block-button.is-style-as-link {
+	.has-blue-background-color &,
+	.has-bright-blue-background-color &,
+	.has-blue-50-background-color &,
+	.has-blue-aaa-background-color &,
+	.has-dark-green-background-color &,
+	.has-orange-background-color &,
+	.has-green-aaa-background-color &,
+	.has-green-background-color &,
+	.has-purple-background-color &,
+	.has-red-background-color &,
+	.has-red-50-background-color &,
+	.has-red-aaa-background-color & {
+		.wp-block-button__link,
+		.wp-block-button__link:hover {
+			color: $wmui-color-base100;
+		}
+	}
+}

--- a/assets/src/sass/helpers/_style-guide-variables-overrides.scss
+++ b/assets/src/sass/helpers/_style-guide-variables-overrides.scss
@@ -4,6 +4,7 @@
 // which can override baseUI definitions.
 
 // Overrides to Base UI color definitions.
+$wmui-color-blue:     #0063bf;
 $wmui-color-blue50:   #0e65c0;
 $wmui-color-blue50:   #3a25ff;
 $wmui-color-blue70:   #c3d8ef;

--- a/assets/src/sass/style.scss
+++ b/assets/src/sass/style.scss
@@ -30,6 +30,7 @@
 @import "components/tables";
 @import "components/header";
 @import "components/dropdown";
+@import "components/group";
 @import "components/searchform";
 @import "components/nav-donate";
 @import "components/nav-logo";

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -17,18 +17,18 @@ $color-palette:
 	blue70          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base50,
 	blue50          $wmui-color-blue50          $wmui-color-base100 $wmui-color-base0,
 	blue-aaa        $wmui-color-blue-aaa        $wmui-color-base100 $wmui-color-base100,
-	bright-blue     $wmui-color-bright-blue     $wmui-color-base100 $wmui-color-base0,
+	bright-blue     $wmui-color-bright-blue     $wmui-color-base0   $wmui-color-base0,
 	bright-blue70   $wmui-color-bright-blue70   $wmui-color-base0   $wmui-color-base50,
-	bright-green    $wmui-color-bright-green    $wmui-color-base0   $wmui-color-base0,
+	bright-green    $wmui-color-bright-green    $wmui-color-base0   $wmui-color-blue50,
 	bright-green70  $wmui-color-bright-green70  $wmui-color-base0   $wmui-color-base50,
 	dark-green      $wmui-color-dark-green      $wmui-color-base100 $wmui-color-base100,
 	dark-green70    $wmui-color-dark-green70    $wmui-color-base0   $wmui-color-base50,
         green           $wmui-color-green           $wmui-color-base100 $wmui-color-base100,
 	green-aaa       $wmui-color-green-aaa       $wmui-color-base100 $wmui-color-base100,
 	green70         $wmui-color-green70         $wmui-color-base0   $wmui-color-base50,
-        orange          $wmui-color-orange          $wmui-color-base100 $wmui-color-base0,
+        orange          $wmui-color-orange      $wmui-color-base0 $wmui-color-base0,
 	orange70        $wmui-color-orange70        $wmui-color-base0   $wmui-color-base50,
-        pink            $wmui-color-pink            $wmui-color-base100 $wmui-color-base0,
+        pink            $wmui-color-pink            $wmui-color-base0 $wmui-color-base0,
 	pink70          $wmui-color-pink70          $wmui-color-base0   $wmui-color-base50,
 	purple          $wmui-color-purple          $wmui-color-base100 $wmui-color-base100,
 	purple70        $wmui-color-purple70        $wmui-color-base0   $wmui-color-base50,
@@ -39,7 +39,7 @@ $color-palette:
 	red-90          $wmui-color-red90           $wmui-color-base0   $wmui-color-blue50,
 	bright-yellow   $wmui-color-bright-yellow   $wmui-color-base0   $wmui-color-blue50,
 	bright-yellow70 $wmui-color-bright-yellow70 $wmui-color-base0   $wmui-color-blue50,
-	yellow          $wmui-color-yellow          $wmui-color-base0   $wmui-color-blue50,
+	yellow          $wmui-color-yellow          $wmui-color-base0   $wmui-color-base0,
 	yellow70        $wmui-color-yellow70        $wmui-color-base0   $wmui-color-blue50,
 	yellow-50       $wmui-color-yellow50        $wmui-color-base0   $wmui-color-blue50,
 	yellow-90       $wmui-color-yellow90        $wmui-color-base0   $wmui-color-blue50;
@@ -66,8 +66,10 @@ $color-palette:
 			color: var(--link-color);
 
 			&::before {
-				@if $link-color == $wmui-color-base100 or $link-color == $wmui-color-blue90 {
+				@if $link-color == $wmui-color-base100 or $link-color == $wmui-color-blue90 or $link-color ==  $wmui-color-accent90 {
 					filter: brightness(0) invert(1);
+				} @else if $link-color == $wmui-color-base0 {
+					filter: brightness(0);
 				}
 			}
 		}
@@ -87,38 +89,38 @@ $color-palette:
 $block-styles:
 	base90          $wmui-color-base90          $wmui-color-base0   $wmui-color-base0  primary,
 	base70          $wmui-color-base70          $wmui-color-base0   $wmui-color-base0  primary,
-	base0           $wmui-color-base0           $wmui-color-base100 $wmui-color-blue50 reverse,
-	blue90          $wmui-color-blue90          $wmui-color-base0   $wmui-color-blue50 primary,
-	blue70          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base50 primary,
+	base0           $wmui-color-base0           $wmui-color-base100 $wmui-color-blue0 reverse,
+	blue90          $wmui-color-blue90          $wmui-color-base0   $wmui-color-base0 primary,
+	blue70          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base0 primary,
 	blue50          $wmui-color-blue50          $wmui-color-base100 $wmui-color-base0  reverse,
 	blue-aaa        $wmui-color-blue-aaa        $wmui-color-base100 $wmui-color-base0  reverse,
-	bright-blue     $wmui-color-bright-blue     $wmui-color-base100 $wmui-color-base0  reverse,
-	bright-blue70   $wmui-color-bright-blue70   $wmui-color-base0   $wmui-color-base50 primary,
+	bright-blue     $wmui-color-bright-blue     $wmui-color-base0   $wmui-color-base0  reverse,
+	bright-blue70   $wmui-color-bright-blue70   $wmui-color-base0   $wmui-color-base0 primary,
 	bright-green    $wmui-color-bright-green    $wmui-color-base0   $wmui-color-base0  reverse,
-	bright-green70  $wmui-color-bright-green70  $wmui-color-base0   $wmui-color-base50 primary,
+	bright-green70  $wmui-color-bright-green70  $wmui-color-base0   $wmui-color-base0 primary,
 	dark-green      $wmui-color-dark-green      $wmui-color-base0   $wmui-color-base0  reverse,
-	dark-green70    $wmui-color-dark-green70    $wmui-color-base0   $wmui-color-base50 primary,
+	dark-green70    $wmui-color-dark-green70    $wmui-color-base0   $wmui-color-base0 primary,
 	green           $wmui-color-green           $wmui-color-base100 $wmui-color-base0  reverse,
 	green-aaa       $wmui-color-green-aaa       $wmui-color-base100 $wmui-color-base0  reverse,
-	green70         $wmui-color-green70         $wmui-color-base0   $wmui-color-base50 primary,
-	orange          $wmui-color-orange          $wmui-color-base100 $wmui-color-base0  reverse,
-	orange70        $wmui-color-orange70        $wmui-color-base0   $wmui-color-base50 primary,
-	pink            $wmui-color-pink            $wmui-color-base100 $wmui-color-base0  reverse,
-	pink70          $wmui-color-pink70          $wmui-color-base0   $wmui-color-base50 primary,
+	green70         $wmui-color-green70         $wmui-color-base0   $wmui-color-base0 primary,
+	orange          $wmui-color-orange          $wmui-color-base0 $wmui-color-base0  reverse,
+	orange70        $wmui-color-orange70        $wmui-color-base0   $wmui-color-base0 primary,
+	pink            $wmui-color-pink            $wmui-color-base0   $wmui-color-base0  reverse,
+	pink70          $wmui-color-pink70          $wmui-color-base0   $wmui-color-base0 primary,
 	purple          $wmui-color-purple          $wmui-color-base100 $wmui-color-base0  reverse,
-	purple70        $wmui-color-purple70        $wmui-color-base0   $wmui-color-base50 primary,
-	donate-red90    $wmui-color-red90           $wmui-color-base0   $wmui-color-red50  primary,
-	red90           $wmui-color-red90           $wmui-color-base0   $wmui-color-red50  primary,
-	red70           $wmui-color-red70           $wmui-color-base0   $wmui-color-red50  primary,
-	red50           $wmui-color-red50           $wmui-color-base100 $wmui-color-base10 reverse,
+	purple70        $wmui-color-purple70        $wmui-color-base0   $wmui-color-base0 primary,
+	donate-red90    $wmui-color-red90           $wmui-color-base0   $wmui-color-base0  primary,
+	red90           $wmui-color-red90           $wmui-color-base0   $wmui-color-base0  primary,
+	red70           $wmui-color-red70           $wmui-color-base0   $wmui-color-base0  primary,
+	red50           $wmui-color-red50           $wmui-color-base100 $wmui-color-base0 reverse,
 	red             $wmui-color-red             $wmui-color-base100 $wmui-color-base0  reverse,
 	red-aaa         $wmui-color-red-aaa         $wmui-color-base100 $wmui-color-base0  reverse,
-	bright-yellow   $wmui-color-bright-yellow   $wmui-color-base0   $wmui-color-blue50 primary,
-	bright-yellow70 $wmui-color-bright-yellow70 $wmui-color-base0   $wmui-color-blue50 primary,
-	yellow          $wmui-color-yellow          $wmui-color-base0   $wmui-color-blue50 primary,
-	yellow50        $wmui-color-yellow50        $wmui-color-base0   $wmui-color-blue50 primary,
-	yellow70        $wmui-color-yellow70        $wmui-color-base0   $wmui-color-blue50 primary,
-	yellow90        $wmui-color-yellow90        $wmui-color-base0   $wmui-color-blue50 primary;
+	bright-yellow   $wmui-color-bright-yellow   $wmui-color-base0   $wmui-color-base0 primary,
+	bright-yellow70 $wmui-color-bright-yellow70 $wmui-color-base0   $wmui-color-base0 primary,
+	yellow          $wmui-color-yellow          $wmui-color-base0   $wmui-color-base0 primary,
+	yellow50        $wmui-color-yellow50        $wmui-color-base0   $wmui-color-base0 primary,
+	yellow70        $wmui-color-yellow70        $wmui-color-base0   $wmui-color-base0 primary,
+	yellow90        $wmui-color-yellow90        $wmui-color-base0   $wmui-color-base0 primary;
 
 @each $name, $background-color, $text-color, $accent-color, $button-style in $block-styles {
 

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -11,28 +11,29 @@ $color-palette:
 	base-80         $wmui-color-base80          $wmui-color-base0   $wmui-color-blue50,
 	base-90         $wmui-color-base90          $wmui-color-base0   $wmui-color-blue50,
 	base-100        $wmui-color-base100         $wmui-color-base10  $wmui-color-blue50,
+	blue            $wmui-color-blue            $wmui-color-base100 $wmui-color-blue90,
 	blue-50         $wmui-color-blue50          $wmui-color-base100 $wmui-color-blue90,
 	blue-90         $wmui-color-blue90          $wmui-color-base0   $wmui-color-blue50,
 	blue70          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base50,
 	blue50          $wmui-color-blue50          $wmui-color-base100 $wmui-color-base0,
-	blue-aaa        $wmui-color-blue-aaa        $wmui-color-base100 $wmui-color-base0,
+	blue-aaa        $wmui-color-blue-aaa        $wmui-color-base100 $wmui-color-base100,
 	bright-blue     $wmui-color-bright-blue     $wmui-color-base100 $wmui-color-base0,
 	bright-blue70   $wmui-color-bright-blue70   $wmui-color-base0   $wmui-color-base50,
 	bright-green    $wmui-color-bright-green    $wmui-color-base0   $wmui-color-base0,
 	bright-green70  $wmui-color-bright-green70  $wmui-color-base0   $wmui-color-base50,
-	dark-green      $wmui-color-dark-green      $wmui-color-base0   $wmui-color-base0,
+	dark-green      $wmui-color-dark-green      $wmui-color-base100 $wmui-color-base100,
 	dark-green70    $wmui-color-dark-green70    $wmui-color-base0   $wmui-color-base50,
-        green           $wmui-color-green           $wmui-color-base100 $wmui-color-base0,
-	green-aaa       $wmui-color-green-aaa       $wmui-color-base100 $wmui-color-base0,
+        green           $wmui-color-green           $wmui-color-base100 $wmui-color-base100,
+	green-aaa       $wmui-color-green-aaa       $wmui-color-base100 $wmui-color-base100,
 	green70         $wmui-color-green70         $wmui-color-base0   $wmui-color-base50,
         orange          $wmui-color-orange          $wmui-color-base100 $wmui-color-base0,
 	orange70        $wmui-color-orange70        $wmui-color-base0   $wmui-color-base50,
         pink            $wmui-color-pink            $wmui-color-base100 $wmui-color-base0,
 	pink70          $wmui-color-pink70          $wmui-color-base0   $wmui-color-base50,
-	purple          $wmui-color-purple          $wmui-color-base100 $wmui-color-base0,
+	purple          $wmui-color-purple          $wmui-color-base100 $wmui-color-base100,
 	purple70        $wmui-color-purple70        $wmui-color-base0   $wmui-color-base50,
-	red             $wmui-color-red             $wmui-color-base100 $wmui-color-base0,
-	red-aaa         $wmui-color-red-aaa         $wmui-color-base100 $wmui-color-base0,
+	red             $wmui-color-red             $wmui-color-base100 $wmui-color-base100,
+	red-aaa         $wmui-color-red-aaa         $wmui-color-base100 $wmui-color-base100,
 	red70           $wmui-color-red70           $wmui-color-base0   $wmui-color-red50,
 	red-50          $wmui-color-red50           $wmui-color-base100 $wmui-color-accent90,
 	red-90          $wmui-color-red90           $wmui-color-base0   $wmui-color-blue50,
@@ -59,6 +60,17 @@ $color-palette:
 		background-color: var(--background-color);
 		color: $text-color;
 		color: var(--text-color);
+
+		.wp-block-shiro-button.is-style-as-link {
+			color: $link-color;
+			color: var(--link-color);
+
+			&::before {
+				@if $link-color == $wmui-color-base100 or $link-color == $wmui-color-blue90 {
+					filter: brightness(0) invert(1);
+				}
+			}
+		}
 	}
 
 	.has-#{$color}-color {

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -89,7 +89,7 @@ $color-palette:
 $block-styles:
 	base90          $wmui-color-base90          $wmui-color-base0   $wmui-color-base0  primary,
 	base70          $wmui-color-base70          $wmui-color-base0   $wmui-color-base0  primary,
-	base0           $wmui-color-base0           $wmui-color-base100 $wmui-color-blue0 reverse,
+	base0           $wmui-color-base0           $wmui-color-base100 $wmui-color-base0 reverse,
 	blue90          $wmui-color-blue90          $wmui-color-base0   $wmui-color-base0 primary,
 	blue70          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base0 primary,
 	blue50          $wmui-color-blue50          $wmui-color-base100 $wmui-color-base0  reverse,

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -369,11 +369,6 @@ function add_theme_supports() {
 			'slug' => 'light-blue',
 			'color' => '#effafd',
 		],
-		[
-			'name' => __( 'Wiki Blue', 'shiro-admin' ),
-			'slug' => 'wiki-blue',
-			'color' => '#3366cc',
-		],
 	] );
 
 	// Disable custom color and gradient selection in the editor.


### PR DESCRIPTION
This is part of ticket [758 - Adding Colors](https://app.zenhub.com/workspaces/wikimedia-foundation-602350f5e5f555000e33e28c/issues/gh/humanmade/wikimedia/758) 

### Add color styles to cards
![ezgif com-resize](https://user-images.githubusercontent.com/55361215/218088277-0b5da1a2-1224-4f7c-87fd-1e9962cb4eb1.gif)
![ezgif com-resize (1)](https://user-images.githubusercontent.com/55361215/218089926-e515c935-7c6a-48e4-bf76-6c323d080364.gif)


### Add the white color link when the background has darker colors
**Back**
<img width="1424" alt="link-bg-editor" src="https://user-images.githubusercontent.com/55361215/218087948-3440fee8-7477-4f08-a745-449868e7b755.png">
**Front**
<img width="1018" alt="link-bg" src="https://user-images.githubusercontent.com/55361215/218087970-ba3d3f83-68f9-4eb5-8bdc-bccf355d4bed.png">

