### PR TITLE
787: Staff Profile Tagging

### DIFF
--- a/assets/src/sass/objects/_header.scss
+++ b/assets/src/sass/objects/_header.scss
@@ -397,6 +397,10 @@ $header-bp-mw: 1049px;
 		@include has-font-size( large );
 		font-family: $font-family-serif;
 		margin: 0;
+
+		> span {
+			display: block;
+		}
 	}
 
 	a {

--- a/single-profile.php
+++ b/single-profile.php
@@ -17,16 +17,16 @@ while ( have_posts() ) :
 	?>
 
 	<?php
-	$role            = get_the_terms( get_the_ID(), 'role' );
+	$roles           = get_the_terms( get_the_ID(), 'role' );
 	$default_heading = get_theme_mod( 'wmf_related_profiles_heading', __( 'Other members of ', 'shiro-admin' ) );
 	$team_name       = '';
-	$parent_name     = $role[0]->name;
-	$parent_link     = get_term_link( $role[0] );
+	$parent_name     = $roles[0]->name;
+	$parent_link     = get_term_link( $roles[0] );
     $connected_user = get_post_meta( get_the_ID(), 'connected_user', true );
 
-	if ( ! empty( $role ) && ! is_wp_error( $role ) ) {
-		$team_name = $role[0]->name;
-		$ancestors = get_ancestors( $role[0]->term_id, 'role' );
+	if ( ! empty( $roles ) && ! is_wp_error( $roles ) ) {
+		$team_name = $roles;
+		$ancestors = get_ancestors( $roles[0]->term_id, 'role' );
 		$parent_id = is_array( $ancestors ) ? end( $ancestors ) : false;
 
 		if ( $parent_id ) {
@@ -128,7 +128,7 @@ while ( have_posts() ) :
 	Credits::get_instance()->pause();
 	$template_args                  = get_post_meta( get_the_ID(), 'profiles', true );
 	$template_args['profiles_list'] = wmf_get_related_profiles( get_the_ID() );
-	$template_args['headline']      = ! empty( $template_args['headline'] ) ? $template_args['headline'] : $default_heading . $team_name;
+	$template_args['headline']      = ! empty( $template_args['headline'] ) ? $template_args['headline'] : $default_heading . $roles[0]->name;
 	get_template_part( 'template-parts/modules/profiles/list', null, $template_args );
 endwhile;
 Credits::get_instance()->resume();

--- a/single-profile.php
+++ b/single-profile.php
@@ -22,7 +22,7 @@ while ( have_posts() ) :
 	$team_name       = '';
 	$parent_name     = $roles[0]->name;
 	$parent_link     = get_term_link( $roles[0] );
-    $connected_user = get_post_meta( get_the_ID(), 'connected_user', true );
+	$connected_user = get_post_meta( get_the_ID(), 'connected_user', true );
 
 	if ( ! empty( $roles ) && ! is_wp_error( $roles ) ) {
 		$team_name = $roles;
@@ -66,50 +66,49 @@ while ( have_posts() ) :
 				?>
 				<?php if ( ! empty( $share_links ) || ! empty( $connected_user ) ) : ?>
 				<div class="rise-up side-list">
-				<?php if ( ! empty( $share_links ) ) : ?>
-					<?php
-					foreach ( $share_links as $link ) :
-
-						?>
-					<div class="link-list mar-right">
+					<?php if ( ! empty( $share_links ) ) : ?>
 						<?php
-						$img = "";
-						if ( is_int(strpos($link['link'],'meta.wikimedia.org') ) ) {
-							$img = get_template_directory_uri() . "/assets/src/svg/globe.svg";
-						}
-						if ( is_int(strpos($link['link'],'mailto')) ) {
-							$img = get_template_directory_uri() . "/assets/src/svg/email.svg";
-						}
-						if ( is_int(strpos($link['link'],'wikipedia.org')) ) {
-							$img = get_template_directory_uri() . "/assets/src/svg/individual/wikipedia.svg";
-						}
-						if ( is_int(strpos($link['link'],'/news/')) ) {
-							$img = get_template_directory_uri() . "/assets/src/svg/individual/wikimedia-blue.svg";
-						}
+						foreach ( $share_links as $link ) :
+							?>
+							<div class="link-list mar-right">
+								<?php
+								$img = '';
+								if ( is_int( strpos( $link['link'], 'meta.wikimedia.org' ) ) ) {
+									$img = get_template_directory_uri() . '/assets/src/svg/globe.svg';
+								}
+								if ( is_int( strpos( $link['link'], 'mailto' ) ) ) {
+									$img = get_template_directory_uri() . '/assets/src/svg/email.svg';
+								}
+								if ( is_int( strpos( $link['link'], 'wikipedia.org' ) ) ) {
+									$img = get_template_directory_uri() . '/assets/src/svg/individual/wikipedia.svg';
+								}
+								if ( is_int( strpos( $link['link'], '/news/' ) ) ) {
+									$img = get_template_directory_uri() . '/assets/src/svg/individual/wikimedia-blue.svg';
+								}
+								?>
+								<div class="bold profile-contacts"><a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>">
+									<img src="<?php echo esc_url( $img ); ?>" alt="">
+									<?php echo esc_html( $link['title'] ); ?>
+								</a></div>
+							</div>
+						<?php endforeach; ?>
+					<?php endif; ?>
+					<?php if ( ! empty( $connected_user ) ) : ?>
+						<?php
+							$authorimg = get_template_directory_uri() . "/assets/src/svg/edit-ltr.svg";
+							if ( is_rtl() ) {
+								$authorimg = get_template_directory_uri() . "/assets/src/svg/edit-rtl.svg";
+							}
+							$authorlink = wmf_get_author_link( $connected_user );
+							$authorlinkcopy = sprintf( /* translators: 1. post title */ __( 'Posts by %s', 'shiro' ), get_the_title() );
 						?>
-						<div class="bold profile-contacts"><a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>">
-							<img src="<?php echo esc_url($img); ?>" alt="">
-							<?php echo esc_html( $link['title'] ); ?>
-                        </a></div>
-					</div>
-					<?php endforeach; ?>
-				<?php endif; ?>
-				<?php if ( ! empty( $connected_user ) ) : ?>
-                    <?php
-						$authorimg = get_template_directory_uri() . "/assets/src/svg/edit-ltr.svg";
-						if ( is_rtl() ) {
-							$authorimg = get_template_directory_uri() . "/assets/src/svg/edit-rtl.svg";
-						}
-                        $authorlink = wmf_get_author_link( $connected_user );
-                        $authorlinkcopy = sprintf( /* translators: 1. post title */ __( 'Posts by %s', 'shiro' ), get_the_title() );
-                    ?>
-                    <div class="link-list mar-right">
-                    <div class="bold profile-contacts"><a href="/news/author/<?php echo esc_attr( $authorlink ); ?>">
-							<img src="<?php echo esc_url($authorimg); ?>" alt="">
-							<?php echo esc_html( $authorlinkcopy ); ?>
-						</a></div>
-                    </div>
-				<?php endif; ?>
+						<div class="link-list mar-right">
+						<div class="bold profile-contacts"><a href="/news/author/<?php echo esc_attr( $authorlink ); ?>">
+								<img src="<?php echo esc_url($authorimg); ?>" alt="">
+								<?php echo esc_html( $authorlinkcopy ); ?>
+							</a></div>
+						</div>
+					<?php endif; ?>
 				</div>
 				<?php endif; ?>
 			</div>

--- a/template-parts/header/profile-single.php
+++ b/template-parts/header/profile-single.php
@@ -12,7 +12,21 @@ $staff_name   = ! empty( $profile_header_data['back_to_label'] ) ? $profile_head
 $team_name    = ! empty( $profile_header_data['team_name'] ) ? $profile_header_data['team_name'] : false;
 $role_name    = ! empty( $profile_header_data['role'] ) ? $profile_header_data['role'] : false;
 $share_links  = ! empty( $profile_header_data['share_links'] ) ? $profile_header_data['share_links'] : '';
-$role_desc    = join(', ', array_filter( [ $role_name, $team_name ] ) );
+$team_url     = get_term_link( $team_name[0]->term_id, $team_name[0]->taxonomy );
+$team_link    = '<a href="' . esc_url( $team_url ) . '">' . esc_html( $team_name[0]->name ) . '</a>';
+$role_desc    = join( ', ', array_filter( [ $role_name, $team_link ] ) );
+
+if ( count( $team_name ) > 1 ) {
+	$role_array = [];
+
+	foreach ( $team_name as $team ) {
+		$url = get_term_link( $team->term_id, $team->taxonomy );
+		$role_array[] = '<a href="' . esc_url( $url ) . '">' . esc_html( $team->name ) . '</a>';
+	}
+
+	$role_desc = $role_name;
+	$role_team = join( ', ', $role_array );
+}
 
 ?>
 
@@ -27,7 +41,13 @@ $role_desc    = join(', ', array_filter( [ $role_name, $team_name ] ) );
 		<h1><?php the_title(); ?></h1>
 
 		<p class="post-meta">
-			<?php echo esc_html( $role_desc ); ?>
+			<?php echo wp_kses_post( $role_desc ); ?>
+
+			<?php if ( count( $team_name ) > 1 ) : ?>
+			<span class="post-meta-team">
+				<?php echo wp_kses_post( $role_team ); ?>
+			</span>
+			<?php endif; ?>
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
This change allows for multiple member profile team tags to display as comma-separated list of links in the front-end. Single tags display next to the role title and are also outputted as a link.

_Multiple tags:_
<img width="705" alt="Screen Shot 2023-03-02 at 7 04 27 PM" src="https://user-images.githubusercontent.com/14046668/222583631-486376df-1a1b-467c-a544-c16d0627b7ac.png">

_Single tag:_
<img width="475" alt="Screen Shot 2023-03-02 at 7 05 20 PM" src="https://user-images.githubusercontent.com/14046668/222583653-ac2eab20-1556-484e-84e9-f36f042ffd0f.png">

For issue https://github.com/humanmade/wikimedia/issues/787.