### PR TITLE
[#764] Move the search field to the header

### DIFF
--- a/assets/src/sass/components/_nav-search.scss
+++ b/assets/src/sass/components/_nav-search.scss
@@ -3,19 +3,9 @@
 	border: 1px solid $border-color-base;
 	border-radius: 2px;
 	box-sizing: border-box;
+	flex: 0 0 rem(220);
 	margin-bottom: 0;
 	width: 100%;
-
-	@media ( min-width: #{$medium-landscape} ) {
-		align-self: center;
-		flex: 0 0 rem(220);
-		margin-right: 0.5rem;
-		order: 26;
-	}
-
-	@media ( max-width: #{$medium-landscape} ) {
-		display: none;
-	}
 
 	[data-dropdown-status="uninitialized"] & {
 		@include target-ie {
@@ -38,6 +28,29 @@
 
 		@media ( min-width: #{$medium-landscape} ) {
 			font-size: 14px;
+		}
+	}
+
+	&--mobile {
+		display: none;
+
+		@media ( max-width: #{$medium-landscape} ) {
+			align-self: flex-start;
+			display: block;
+			margin-left: auto;
+			margin-top: rem(12);
+			order: 1;
+		}
+	}
+
+	&--desktop {
+		display: block;
+		align-self: center;
+		margin-right: 0.5rem;
+		order: 26;
+
+		@media ( max-width: #{$medium-landscape} ) {
+			display: none;
 		}
 	}
 }

--- a/assets/src/sass/components/_nav-search.scss
+++ b/assets/src/sass/components/_nav-search.scss
@@ -7,11 +7,14 @@
 	width: 100%;
 
 	@media ( min-width: #{$medium-landscape} ) {
-		align-self: flex-start;
+		align-self: center;
 		flex: 0 0 rem(220);
-		margin-left: auto;
-		margin-top: rem(12);
-		order: 1;
+		margin-right: 0.5rem;
+		order: 26;
+	}
+
+	@media ( max-width: #{$medium-landscape} ) {
+		display: none;
 	}
 
 	[data-dropdown-status="uninitialized"] & {

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -14,9 +14,6 @@
 		width: 100%;
 
 		@media ( min-width: #{$primary-nav-breakpoint} ) {
-			align-items: flex-start;
-			display: flex;
-			justify-content: flex-start;
 			width: 100%;
 		}
 
@@ -76,6 +73,7 @@
 		align-items: start;
 		display: flex;
 		flex-wrap: wrap;
+		justify-content: space-between;
 		list-style: none;
 
 		[data-dropdown-status="initialized"] & {

--- a/assets/src/sass/components/_searchform.scss
+++ b/assets/src/sass/components/_searchform.scss
@@ -9,7 +9,7 @@
 		// remove browser button styling
 		border: none;
 		margin: 0;
-		width: auto;
+		width: max-content;
 		overflow: visible;
 		background: transparent;
 		color: inherit;
@@ -26,6 +26,7 @@
 		bottom: rem(2);
 		right: rem(2);
 		padding: 0 rem( 3 );
+		margin-left: auto;
 
 		&:focus {
 			@include focus-ring($hex: false, $inset: true);

--- a/template-parts/site-header/wrapper.php
+++ b/template-parts/site-header/wrapper.php
@@ -17,7 +17,7 @@ $translations = array_filter( wmf_get_translations(), function ( $translation ) 
 
 <div class="site-header">
 	<div class="site-header__inner"
-		<?php if ( count( $translations ) > 0 ): ?>
+		<?php if ( count( $translations ) > 0 ) : ?>
 			data-dropdown="language-switcher" data-dropdown-toggle=".language-switcher__button"
 			data-dropdown-status="uninitialized"
 			data-dropdown-content=".language-switcher__content"
@@ -26,9 +26,7 @@ $translations = array_filter( wmf_get_translations(), function ( $translation ) 
 		<?php get_template_part( 'template-parts/site-header/toggle' ); ?>
 		<?php get_template_part( 'template-parts/site-header/logo' ); ?>
 		<?php get_template_part( 'template-parts/site-navigation/search' ); ?>
-		<?php get_template_part( 'template-parts/site-header/language-switcher',
-			null,
-			[ 'translations' => $translations ] ); ?>
+		<?php get_template_part( 'template-parts/site-header/language-switcher', null, [ 'translations' => $translations ] ); ?>
 		<?php get_template_part( 'template-parts/site-header/donate' ); ?>
 	</div>
 </div>

--- a/template-parts/site-header/wrapper.php
+++ b/template-parts/site-header/wrapper.php
@@ -25,6 +25,7 @@ $translations = array_filter( wmf_get_translations(), function ( $translation ) 
 		<?php endif; ?>>
 		<?php get_template_part( 'template-parts/site-header/toggle' ); ?>
 		<?php get_template_part( 'template-parts/site-header/logo' ); ?>
+		<?php get_template_part( 'template-parts/site-navigation/search' ); ?>
 		<?php get_template_part( 'template-parts/site-header/language-switcher',
 			null,
 			[ 'translations' => $translations ] ); ?>

--- a/template-parts/site-header/wrapper.php
+++ b/template-parts/site-header/wrapper.php
@@ -25,7 +25,9 @@ $translations = array_filter( wmf_get_translations(), function ( $translation ) 
 		<?php endif; ?>>
 		<?php get_template_part( 'template-parts/site-header/toggle' ); ?>
 		<?php get_template_part( 'template-parts/site-header/logo' ); ?>
-		<?php get_template_part( 'template-parts/site-navigation/search' ); ?>
+		<div class='nav-search nav-search--desktop'>
+			<?php get_template_part( 'template-parts/site-navigation/search' ); ?>
+		</div>
 		<?php get_template_part( 'template-parts/site-header/language-switcher', null, [ 'translations' => $translations ] ); ?>
 		<?php get_template_part( 'template-parts/site-header/donate' ); ?>
 	</div>

--- a/template-parts/site-navigation/search.php
+++ b/template-parts/site-navigation/search.php
@@ -1,10 +1,8 @@
 <?php
-
 /**
  * Adds nav search form
  *
  * @package shiro
  */
 
-?>
-<?php get_search_form( true ); ?>
+get_search_form( true );

--- a/template-parts/site-navigation/search.php
+++ b/template-parts/site-navigation/search.php
@@ -7,6 +7,4 @@
  */
 
 ?>
-<div class="nav-search">
-	<?php get_search_form( true ); ?>
-</div>
+<?php get_search_form( true ); ?>

--- a/template-parts/site-navigation/wrapper.php
+++ b/template-parts/site-navigation/wrapper.php
@@ -4,6 +4,7 @@
  *
  * @package shiro
  */
+
 ?>
 <nav class="primary-nav">
 	<div class="primary-nav__drawer" data-dropdown-content="primary-nav">

--- a/template-parts/site-navigation/wrapper.php
+++ b/template-parts/site-navigation/wrapper.php
@@ -8,8 +8,9 @@
 ?>
 <nav class="primary-nav">
 	<div class="primary-nav__drawer" data-dropdown-content="primary-nav">
-		<?php
-		get_template_part( 'template-parts/site-navigation/menu' );
-		?>
+		<div class='nav-search nav-search--mobile'>
+			<?php get_template_part( 'template-parts/site-navigation/search' ); ?>
+		</div>
+		<?php get_template_part( 'template-parts/site-navigation/menu' ); ?>
 	</div>
 </nav>

--- a/template-parts/site-navigation/wrapper.php
+++ b/template-parts/site-navigation/wrapper.php
@@ -8,7 +8,6 @@
 <nav class="primary-nav">
 	<div class="primary-nav__drawer" data-dropdown-content="primary-nav">
 		<?php
-		get_template_part( 'template-parts/site-navigation/search' );
 		get_template_part( 'template-parts/site-navigation/menu' );
 		?>
 	</div>


### PR DESCRIPTION
This PR intends to move the search field to the header.

## Tasks accomplished
- [x] Search field is next to the website header left of the language lists
- [x] For Arabic, the search field should be to the right of the language list
- [x] Fix alignment for the Arabic search magnifying glass icon
- [x] Navigation drawer items using the entire content container

## Related ticket
https://github.com/humanmade/Wikimedia/issues/764

## Current - non-Arabic
![image](https://user-images.githubusercontent.com/90911997/223430649-8069002d-a82e-44f7-b16a-b0c5c0f212ad.png)

## Current - RTL Arabic
![image](https://user-images.githubusercontent.com/90911997/223431838-753eabc5-e044-4812-8ff0-d49a5d32352f.png)

## After changes - non-Arabic
![image](https://user-images.githubusercontent.com/90911997/223431263-0162e1df-1b89-40cc-96d4-44e12057d5f3.png)

## After changes - RTL Arabic
![image](https://user-images.githubusercontent.com/90911997/223431975-4a489835-0987-4314-af5d-652527865200.png)

**NOTE: Search box is hidden when viewport width is <= 1023 px.**

## Hidden search box for smaller viewports (width <= 1023 px)
![image](https://user-images.githubusercontent.com/90911997/223432495-0b5d52b3-0cd1-4184-97a4-dc608df70370.png)

