### PR TITLE
[#767]: Add "hide page title" control

### DIFF
--- a/assets/src/editor/hooks/useMeta.js
+++ b/assets/src/editor/hooks/useMeta.js
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Return the current meta value and a setter function.
+ *
+ * @param {string} metaKey - Meta key.
+ * @param {*} [defaultValue] - Optional. Default value to use.
+ * @returns {Array} Array containing the current meta value and a function to update it.
+ */
+export default function useMeta( metaKey, defaultValue ) {
+	const { editPost } = useDispatch( 'core/editor' );
+
+	const meta = useSelect(
+		( select ) => select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+	);
+
+	const setMeta = useCallback(
+		( value ) => editPost( { meta: { [metaKey]: value } } ),
+		[ editPost, metaKey ]
+	);
+
+	return [
+		meta?.[ metaKey ] ?? defaultValue,
+		setMeta,
+	];
+}

--- a/assets/src/editor/plugins/hide-page-title-controls/index.js
+++ b/assets/src/editor/plugins/hide-page-title-controls/index.js
@@ -23,7 +23,7 @@ export const settings = {
 	render: function Render() {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 
-		const [ hideTitle, setHideTitle ] = useMeta( '_wmf_hide_title', false );
+		const [ hideTitle, setHideTitle ] = useMeta( 'wmf_hide_title', false );
 
 		if ( postType !== 'page' ) {
 			return;

--- a/assets/src/editor/plugins/hide-page-title-controls/index.js
+++ b/assets/src/editor/plugins/hide-page-title-controls/index.js
@@ -1,0 +1,43 @@
+import { ToggleControl } from '@wordpress/components';
+import { select } from '@wordpress/data';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+
+import useMeta from '../../hooks/useMeta';
+
+/**
+ * Adds a toggle control to hide the page title, in the post status box.
+ */
+
+/**
+ * The name of this editor plugin. Required.
+ */
+export const name = 'hide-page-title-control';
+
+export const settings = {
+	/**
+	 * "Render" component for this plugin.
+	 *
+	 * Renders a toggle control in the post status sidebar panel to hide the page title.
+	 */
+	render: function Render() {
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		const [ hideTitle, setHideTitle ] = useMeta( '_wmf_hide_title', false );
+
+		if ( postType !== 'page' ) {
+			return;
+		}
+
+		return  (
+			<PluginPostStatusInfo>
+				<ToggleControl
+					label={ __( 'Hide this page title', 'shiro-admin' ) }
+					help={ __( 'Use this option to avoid redundant titles, for example if the page hero contains its title.', 'shiro-admin' ) }
+					checked={ hideTitle }
+					onChange={ setHideTitle }
+				/>
+			</PluginPostStatusInfo>
+		);
+	},
+};

--- a/assets/src/sass/objects/_header.scss
+++ b/assets/src/sass/objects/_header.scss
@@ -212,7 +212,7 @@ $header-bp-mw: 1049px;
 		margin-top: rem(30);
 		width: 100%;
 
-		body.hide-page-title & {
+		body.hide-page-title & h1 {
 			@extend .visually-hidden
 		}
 	}

--- a/assets/src/sass/objects/_header.scss
+++ b/assets/src/sass/objects/_header.scss
@@ -211,6 +211,10 @@ $header-bp-mw: 1049px;
 		z-index: 2;
 		margin-top: rem(30);
 		width: 100%;
+
+		body.hide-page-title & {
+			@extend .visually-hidden
+		}
 	}
 
 	&.featured-photo--content-left .header-content h2.eyebrow.h4:first-child {

--- a/functions.php
+++ b/functions.php
@@ -336,6 +336,7 @@ Network_Settings\bootstrap();
 require get_template_directory() . '/inc/post-types/profile.php';
 require get_template_directory() . '/inc/post-types/story.php';
 require get_template_directory() . '/inc/post-types/post.php';
+require get_template_directory() . '/inc/post-types/page.php';
 
 /**
  * Logic for Custom Page Templates.

--- a/inc/post-types/page.php
+++ b/inc/post-types/page.php
@@ -9,7 +9,7 @@
  * Registers the "hide page title" meta field
  */
 function wmf_page_init() {
-	register_post_meta( 'page', '_wmf_hide_title', [
+	register_post_meta( 'page', 'wmf_hide_title', [
 		'type' => 'boolean',
 		'single' => true,
 		'show_in_rest' => true,
@@ -25,7 +25,7 @@ add_action( 'init', 'wmf_page_init' );
  * @return string[] Updated body classes.
  */
 function wmf_page_filter_body_class( $body_classes ) {
-	if ( get_post_type() === 'page' && get_post_meta( get_the_ID(), '_wmf_hide_title', true ) ) {
+	if ( get_post_type() === 'page' && get_post_meta( get_the_ID(), 'wmf_hide_title', true ) ) {
 		$body_classes[] = 'hide-page-title';
 	}
 

--- a/inc/post-types/page.php
+++ b/inc/post-types/page.php
@@ -5,7 +5,6 @@
  * @package shiro
  */
 
-
 /**
  * Registers the "hide page title" meta field
  */
@@ -21,6 +20,9 @@ add_action( 'init', 'wmf_page_init' );
 
 /**
  * Filter the body class to include "hide-page-title" if the hide title meta is set.
+ *
+ * @param string[] $body_classes Body classes assigned to the request.
+ * @return string[] Updated body classes.
  */
 function wmf_page_filter_body_class( $body_classes ) {
 	if ( get_post_type() === 'page' && get_post_meta( get_the_ID(), '_wmf_hide_title', true ) ) {

--- a/inc/post-types/page.php
+++ b/inc/post-types/page.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Registers additional supports for the core "page" post type.
+ *
+ * @package shiro
+ */
+
+
+/**
+ * Registers the "hide page title" meta field
+ */
+function wmf_page_init() {
+	register_post_meta( 'page', '_wmf_hide_title', [
+		'type' => 'boolean',
+		'single' => true,
+		'show_in_rest' => true,
+	] );
+}
+
+add_action( 'init', 'wmf_page_init' );
+
+/**
+ * Filter the body class to include "hide-page-title" if the hide title meta is set.
+ */
+function wmf_page_filter_body_class( $body_classes ) {
+	if ( get_post_type() === 'page' && get_post_meta( get_the_ID(), '_wmf_hide_title', true ) ) {
+		$body_classes[] = 'hide-page-title';
+	}
+
+	return $body_classes;
+}
+
+add_filter( 'body_class', 'wmf_page_filter_body_class' );
+


### PR DESCRIPTION
Adds a toggle control on the page status box, which toggles whether the page title will be displayed or visually hidden.

![image](https://user-images.githubusercontent.com/665992/223564442-904e139f-105f-45cf-855c-2bbb8d84c489.png)
