### PR TITLE
Fix asset manifest filename reference for dev server

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -14,7 +14,7 @@ use Asset_Loader\Manifest;
  */
 function get_manifest_path() {
 	return  Manifest\get_active_manifest( [
-		get_template_directory() . '/assets/dist/asset-manifest.json',
+		get_template_directory() . '/assets/dist/development-asset-manifest.json',
 		get_template_directory() . '/assets/dist/production-asset-manifest.json'
 	] );
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -8,13 +8,15 @@ namespace WMF\Assets;
 use Asset_Loader\Manifest;
 
 /**
- * Get asset manifest path.
+ * Get the active asset manifest path.
+ *
  * Uses dev server if running, otherwise loads from production asset manifest.
+ *
  * @return string|null
  */
 function get_manifest_path() {
-	return  Manifest\get_active_manifest( [
+	return Manifest\get_active_manifest( [
 		get_template_directory() . '/assets/dist/development-asset-manifest.json',
-		get_template_directory() . '/assets/dist/production-asset-manifest.json'
+		get_template_directory() . '/assets/dist/production-asset-manifest.json',
 	] );
 }


### PR DESCRIPTION
Webpack Helpers now uses "development-asset-manifest.json" as the default filename for an asset manifest in dev mode, but the theme was still looking for the old "asset-manifest.json". This change makes it possible to develop frontend assets using `npm run start:webpack:theme`.


This isn't the whole solution for #779, but I've attached it to that issue because this is a prerequisite for being able to even use the dev server at all.
