### PR TITLE
[#765] Enable dropdowns on desktop for all sections

### DIFF
--- a/assets/src/sass/components/_dropdown.scss
+++ b/assets/src/sass/components/_dropdown.scss
@@ -31,8 +31,10 @@
 }
 
 [data-dropdown-backdrop="active"] {
-	opacity: 0.6;
-	pointer-events: auto;
+	@media (max-width: $primary-nav-breakpoint) {
+		opacity: 0.6;
+		pointer-events: auto;
+	}
 }
 
 [data-dropdown-toggle][disabled] {

--- a/assets/src/sass/components/_header.scss
+++ b/assets/src/sass/components/_header.scss
@@ -7,4 +7,8 @@
 	  padding-bottom: 0;
 	}
   }
+
+	&__dropdown-spacing {
+		margin-bottom: rem(60);
+	}
 }

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -245,6 +245,10 @@
 		&:focus {
 			@include focus-ring;
 		}
+
+		@media ( min-width: #{$primary-nav-breakpoint} ) {
+			background-size: 37.5%;
+		}
 	}
 
 	.sub-menu {

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -138,7 +138,7 @@
 			// A toggleable sub-menu should be displayed over the open one.
 			&[data-toggleable="yes"][data-visible="yes"] .sub-menu {
 				background-color: $color-white;
-				z-index: 1;
+				z-index: 11; // Ensure this renders over the menu-item-bottom-line active item marker.
 			}
 
 			a {

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -138,7 +138,15 @@
 			// A toggleable sub-menu should be displayed over the open one.
 			&[data-toggleable="yes"][data-visible="yes"] .sub-menu {
 				background-color: $color-white;
+				padding: rem(6) rem(40);
 				z-index: 11; // Ensure this renders over the menu-item-bottom-line active item marker.
+
+				// When toggled, the relative parent is different, so this needs to be positioned differently.
+				[data-subnav-visible="yes"] & {
+					box-sizing: content-box;
+					margin-left: rem(-40);
+					margin-right: rem(-40);
+				}
 			}
 
 			a {

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -135,6 +135,12 @@
 				flex-wrap: wrap;
 			}
 
+			// A toggleable sub-menu should be displayed over the open one.
+			&[data-toggleable="yes"][data-visible="yes"] .sub-menu {
+				background-color: $color-white;
+				z-index: 1;
+			}
+
 			a {
 				align-items: flex-start;
 				color: $wmui-color-base0;
@@ -224,9 +230,9 @@
 			transform: rotateX( 180deg );
 		}
 
-		&[hidden] {
-			display: none;
-		}
+		//&[hidden] {
+			//display: none;
+		//}
 
 		&:focus {
 			@include focus-ring;

--- a/assets/src/sass/components/_primary-nav.scss
+++ b/assets/src/sass/components/_primary-nav.scss
@@ -230,9 +230,9 @@
 			transform: rotateX( 180deg );
 		}
 
-		//&[hidden] {
-			//display: none;
-		//}
+		&[hidden] {
+			display: none;
+		}
 
 		&:focus {
 			@include focus-ring;

--- a/assets/src/scripts/modules/dropdown.js
+++ b/assets/src/scripts/modules/dropdown.js
@@ -461,6 +461,13 @@ dropdownMenuItems.forEach( menuItem => {
 } );
 
 /**
+ * Adds class if there's dropdown menu.
+ */
+if ( dropdownMenuItems.lenght !== 0 ) {
+	document.querySelector( 'header' ).classList.add( 'header-default__dropdown-spacing' );
+}
+
+/**
  * Show dropdown.
  *
  * @param {HTMLBodyElement} event document.menu-item['data-dropdown'].

--- a/assets/src/scripts/modules/dropdown.js
+++ b/assets/src/scripts/modules/dropdown.js
@@ -451,6 +451,39 @@ function teardown() {
 	}
 }
 
+/**
+ * Selects all menu items that have a dropdown and add event listeners for mouse enter and mouse leave.
+ */
+const dropdownMenuItems = [ ...document.querySelectorAll( '[data-dropdown].menu-item' ) ];
+dropdownMenuItems.forEach( menuItem => {
+	menuItem.addEventListener( 'mouseenter', showDropDown );
+	menuItem.addEventListener( 'mouseleave', mouseLeaveDelay );
+} );
+
+/**
+ * Show dropdown.
+ *
+ * @param {HTMLBodyElement} event document.menu-item['data-dropdown'].
+ */
+function showDropDown( event ) {
+	event.target.dataset.visible = 'yes';
+	event.target.dataset.trap = 'active';
+	event.target.dataset.backdrop = 'active';
+}
+
+/**
+ * Hide dropdown after 50ms.
+ *
+ * @param {HTMLBodyElement} event for .mennu-item[data-dropdown].
+ */
+function mouseLeaveDelay( event ) {
+	setTimeout( () => {
+		event.target.dataset.visible = 'no';
+		event.target.dataset.trap = 'inactive';
+		event.target.dataset.backdrop = 'inactive';
+	}, 50 );
+}
+
 export default initialize( setup, teardown );
 export {
 	_backdrop as backdrop,

--- a/assets/src/scripts/modules/site-header.js
+++ b/assets/src/scripts/modules/site-header.js
@@ -26,6 +26,19 @@ function createObserver() {
 }
 
 /**
+ * Is a sub-menu be opened by default?
+ *
+ * Detects whether an subnav item is expanded by virtue of being the current
+ * menu item or current menu ancestor.
+ *
+ * @param {HTMLElement} subNav Sub-menu to check.
+ * @returns {boolean} True if the element should be expanded by default.
+ */
+function isSubNavExpanded( subNav ) {
+	return !! subNav.closest( '.current-menu-item, .current-menu-parent' );
+}
+
+/**
  * Manipulate primary nav to have the viewport-correct behavior.
  *
  * The primary nav behaves differently on "mobile" and "desktop"--it uses
@@ -47,12 +60,11 @@ function processEntry( entry ) {
 			_primaryNav.dataset.visible = 'yes';
 			_primaryNav.dataset.toggleable = 'no';
 			_primaryNav.dataset.backdrop = 'inactive';
-			_primaryNav.dataset.trap = 'inactive';
+			_primaryNav.dataset.trap = 'active';
 
 			 // Make subnavs toggleable, and set visibilty as expected.
 			_subNavMenus.forEach( _subNavMenu => {
-				const isExpanded = !! _subNavMenu.closest( '.current-menu-item, .current-menu-parent' );
-
+				const isExpanded = isSubNavExpanded( _subNavMenu );
 				_subNavMenu.dataset.visible = isExpanded ? 'yes' : 'no';
 				_subNavMenu.dataset.toggleable = isExpanded ? 'no' : 'yes';
 				_subNavMenu.dropdown.toggle.removeAttribute( 'hidden' );
@@ -69,7 +81,17 @@ function processEntry( entry ) {
 			} );
 		}
 	} else if ( target.classList.contains( 'sub-menu' ) ) {
-		target.closest( '[data-dropdown]' ).dataset.trap = 'inactive';
+		const currentParentItem = target.closest( '[data-dropdown]' );
+
+		// If expanding one section, all others should close.
+		if ( currentParentItem.dataset.visible === 'yes' ) {
+			[ ..._subNavMenus ].filter( menu => menu !== currentParentItem )
+				.forEach( item => {
+					item.dataset.visible = isSubNavExpanded( item ) ? 'yes' : 'no';
+				} );
+		} else {
+			currentParentItem.dataset.trap = 'inactive';
+		}
 	}
 }
 

--- a/assets/src/scripts/modules/site-header.js
+++ b/assets/src/scripts/modules/site-header.js
@@ -49,10 +49,10 @@ function processEntry( entry ) {
 			_primaryNav.dataset.backdrop = 'inactive';
 			_primaryNav.dataset.trap = 'inactive';
 
-			// Make subnavs not toggleable.
+			 // Make subnavs toggleable.
 			_subNavMenus.forEach( _subNavMenu => {
-				_subNavMenu.dataset.toggleable = 'no';
-				_subNavMenu.dropdown.toggle.hidden = true;
+				//_subNavMenu.dataset.toggleable = 'yes';
+				_subNavMenu.dropdown.toggle.removeAttribute( 'hidden' );
 			} );
 		} else {
 			// We're on mobile

--- a/assets/src/scripts/modules/site-header.js
+++ b/assets/src/scripts/modules/site-header.js
@@ -49,9 +49,12 @@ function processEntry( entry ) {
 			_primaryNav.dataset.backdrop = 'inactive';
 			_primaryNav.dataset.trap = 'inactive';
 
-			 // Make subnavs toggleable.
+			 // Make subnavs toggleable, and set visibilty as expected.
 			_subNavMenus.forEach( _subNavMenu => {
-				//_subNavMenu.dataset.toggleable = 'yes';
+				const isExpanded = !! _subNavMenu.closest( '.current-menu-item, .current-menu-parent' );
+
+				_subNavMenu.dataset.visible = isExpanded ? 'yes' : 'no';
+				_subNavMenu.dataset.toggleable = isExpanded ? 'no' : 'yes';
 				_subNavMenu.dropdown.toggle.removeAttribute( 'hidden' );
 			} );
 		} else {

--- a/inc/classes/walkers/class-walker-main-nav.php
+++ b/inc/classes/walkers/class-walker-main-nav.php
@@ -14,7 +14,7 @@ class Walker_Main_Nav extends \Walker_Nav_Menu {
 
 	// Private variable for the current menu item.
 	private $currentItemID;
-	
+
 	/**
 	 * Starts the list before the elements are added.
 	 *
@@ -32,7 +32,7 @@ class Walker_Main_Nav extends \Walker_Nav_Menu {
 			'nav-sub-menu-'. $this->currentItemID,
 		);
 		$class_names = implode( ' ', $classes );
-	
+
 		// Build HTML for output.
 		$output .= "\n" . $indent . '<ul class="' . esc_attr( $class_names ) . '" data-dropdown-content="nav-sub-menu-'. $this->currentItemID . '">' . "\n";
 	}
@@ -70,7 +70,10 @@ class Walker_Main_Nav extends \Walker_Nav_Menu {
 
 		// Build HTML.
 		$active_classes = [ 'current-menu-item', 'current-menu-ancestor' ];
-		$output .= 
+
+		$is_open = count( array_intersect( $active_classes, $classes ) ) > 0;
+
+		$output .=
 			$indent
 			. '<li id="nav-menu-item-'. $item->ID . '"'
 			. ' class="' . $class_names . '"'
@@ -78,8 +81,8 @@ class Walker_Main_Nav extends \Walker_Nav_Menu {
 				' data-dropdown="nav-sub-menu-' . $item->ID . '"'
 				. ' data-dropdown-content=".nav-sub-menu-'. $item->ID . '"'
 				. ' data-dropdown-toggle=".nav-sub-menu-button-'. $item->ID . '"'
-				. ' data-visible="' . ( count( array_intersect( $active_classes, $classes ) ) > 0 ? 'yes' : 'no' ) . '"'
-				. ' data-toggleable="no"'
+				. ' data-visible="' . ( $is_open ? 'yes' : 'no' ) . '"'
+				. ' data-toggleable="' . ( $is_open ? 'no' : 'yes' ) . '"'
 			: '' )
 			. '>';
 
@@ -103,11 +106,12 @@ class Walker_Main_Nav extends \Walker_Nav_Menu {
 
 		if ( in_array( 'menu-item-has-children', $classes, true ) ) {
 			$label = __( 'Expand submenu for ', 'shiro' ) . apply_filters( 'the_title', $item->title, $item->ID );
-			$output .= 
+			$output .=
 			'<button class="menu-item__expand nav-sub-menu-button-'. $item->ID . '"'
 			. ' hidden'
 			. ' aria-label="' . esc_attr( $label ) . '"'
-			. ' aria-expanded="' . ( count( array_intersect( $active_classes, $classes ) ) > 0 ? 'true' : 'false' ) . '"'
+			. ' aria-expanded="' . ( $is_open ? 'true' : 'false' ) . '"'
+			. ( $is_open ? ' disabled="disabled"' : '' )
 			. ' data-dropdown-toggle="nav-sub-menu-'. $item->ID . '">'
 			. '<span class="btn-label-a11y">'
 			. esc_html( $label )


### PR DESCRIPTION
Updates the markup so that dropdown menus are initialized properly on desktop, just like on mobile. Ready for code review, but I also want to get some user testing done, since this design isn't at all obvious in the context of drop downs.

These dropdowns work on click or keyboard, but not on hover, and actually as it stands the designs don't really allow for hover interaction without substantial rework.
