### PR TITLE
[#763] Improvements for search results page

### DIFF
--- a/assets/src/sass/content/_content.scss
+++ b/assets/src/sass/content/_content.scss
@@ -9,3 +9,7 @@
 /* Transparency reports
 --------------------------------------------- */
 @import "transparency-report";
+
+/* Search results
+--------------------------------------------- */
+@import "search-results";

--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -3,7 +3,6 @@
 	&__tabs {
 		border-bottom: 1px solid $wmui-color-base70;
 		margin-bottom: 2rem !important;
-		padding-bottom: 6px !important;
 		padding-top: 2rem !important;
 
 		a {
@@ -14,6 +13,7 @@
 			background-color: $wmui-color-base80;
 			text-decoration: none;
 			color: #000;
+			display: inline-block;
 
 			&:hover {
 				background-color: $wmui-color-base90;

--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -1,0 +1,33 @@
+// Group all style customizations for the 2019-2 transparency report together.
+.search-results {
+	&__tabs {
+		border-bottom: 1px solid #ccc;
+		margin-bottom: 2rem !important;
+		padding-bottom: 0.35rem !important;
+		padding-top: 2rem !important;
+
+		a {
+			padding: 0.5rem 1rem;
+			margin-right: 0.35rem;
+			border: 1px solid #ccc;
+			border-bottom: none;
+			background-color: #eee;
+			text-decoration: none;
+			color: #000;
+
+			&:hover {
+				background-color: #ddd;
+			}
+
+			&.active {
+				background-color: #fff;
+				border-bottom: 1px solid #fff;
+				font-weight: 800;
+			}
+		}
+	}
+}
+
+#search-results .blog-post:not(:last-child) {
+	border-bottom: 1px solid $wmui-color-base80;
+}

--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -1,7 +1,7 @@
 // Group all style customizations for the 2019-2 transparency report together.
 .search-results {
 	&__tabs {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid $wmui-color-base70;
 		margin-bottom: 2rem !important;
 		padding-bottom: 6px !important;
 		padding-top: 2rem !important;
@@ -9,19 +9,19 @@
 		a {
 			padding: 0.5rem 1rem;
 			margin-right: 0.35rem;
-			border: 1px solid #ccc;
+			border: 1px solid $wmui-color-base70;
 			border-bottom: none;
-			background-color: #eee;
+			background-color: $wmui-color-base80;
 			text-decoration: none;
 			color: #000;
 
 			&:hover {
-				background-color: #ddd;
+				background-color: $wmui-color-base90;
 			}
 
 			&.active {
-				background-color: #fff;
-				border-bottom: 1px solid #fff;
+				background-color: $wmui-color-base100;
+				border-bottom: 1px solid $wmui-color-base100;
 				font-weight: 800;
 			}
 		}

--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -3,7 +3,7 @@
 	&__tabs {
 		border-bottom: 1px solid #ccc;
 		margin-bottom: 2rem !important;
-		padding-bottom: 0.35rem !important;
+		padding-bottom: 6px !important;
 		padding-top: 2rem !important;
 
 		a {

--- a/functions.php
+++ b/functions.php
@@ -510,6 +510,11 @@ add_action( 'admin_menu', 'shiro_link_reusable_blocks_url' );
 function shiro_add_slug_body_class( $classes ) {
 	global $post;
 
+	// ignore it for search pages
+	if ( is_search() ) {
+		return $classes;
+	}
+
 	if ( isset( $post ) ) {
 		$classes[] = $post->post_type . '-' . $post->post_name;
 	}

--- a/functions.php
+++ b/functions.php
@@ -372,6 +372,11 @@ require_once get_template_directory() . '/inc/stories.php';
 Stories_Customisations\init();
 
 /**
+ * Search page customizations.
+ */
+require_once get_template_directory() . '/inc/search.php';
+
+/**
  * Modify the document title for the 404 page
  *
  * @param array $title_parts Document title parts.

--- a/inc/editor/blocks/blog-post.php
+++ b/inc/editor/blocks/blog-post.php
@@ -51,10 +51,6 @@ function render_block( $attributes ) {
 
 	$post_query = new \WP_Query( [
 		'post_type' => [ 'post', 'page' ],
-		'orderby'   => [
-			'relevance' => 'DESC',
-			'date'      => 'DESC',
-		],
 		'p'         => (int) $id,
 	] );
 

--- a/inc/editor/blocks/blog-post.php
+++ b/inc/editor/blocks/blog-post.php
@@ -50,7 +50,11 @@ function render_block( $attributes ) {
 	}
 
 	$post_query = new \WP_Query( [
-		'post_type' => 'post',
+		'post_type' => array('post', 'page'),
+		'orderby'   => array(
+			'relevance' => 'DESC',
+			'date'      => 'DESC',
+		),
 		'p'         => (int) $id,
 	] );
 

--- a/inc/editor/blocks/blog-post.php
+++ b/inc/editor/blocks/blog-post.php
@@ -50,11 +50,11 @@ function render_block( $attributes ) {
 	}
 
 	$post_query = new \WP_Query( [
-		'post_type' => array('post', 'page'),
-		'orderby'   => array(
+		'post_type' => [ 'post', 'page' ],
+		'orderby'   => [
 			'relevance' => 'DESC',
 			'date'      => 'DESC',
-		),
+		],
 		'p'         => (int) $id,
 	] );
 

--- a/inc/search.php
+++ b/inc/search.php
@@ -6,13 +6,13 @@
  */
 
 /**
- * Remove post_type = 'profile' from search results.
+ * Restrict search results to news (posts) and pages.
  *
  * @param object $query Full WP_Query object.
  *
  * @return void
  */
-function wmf_remove_profile_from_search( $query ) {
+function wmf_restrict_search( $query ) {
 	if ( $query->is_search() && $query->is_main_query() && ! isset( $_GET['post_type'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$query->set( 'post_type', [
 			'post',
@@ -20,4 +20,19 @@ function wmf_remove_profile_from_search( $query ) {
 		] );
 	}
 }
-add_action( 'pre_get_posts', 'wmf_remove_profile_from_search' );
+add_action( 'pre_get_posts', 'wmf_restrict_search' );
+
+/**
+ * Order search by relevance.
+ *
+ * @param object $query Full WP_Query object.
+ *
+ * @return void
+ */
+function wmf_order_search_by_relevance( $query ) {
+	if ( $query->is_search() && $query->is_main_query() ) {
+		$query->set( 'orderby', 'relevance' );
+		$query->set( 'order', 'DESC' );
+	}
+}
+add_action( 'pre_get_posts', 'wmf_order_search_by_relevance' );

--- a/inc/search.php
+++ b/inc/search.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Search related functions.
+ *
+ * @package shiro
+ */
+
+/**
+ * Remove post_type = 'profile' from search results.
+ *
+ * @param object $query Full WP_Query object.
+ *
+ * @return void
+ */
+function wmf_remove_profile_from_search( $query ) {
+	if ( $query->is_search() && $query->is_main_query() && ! isset( $_GET['post_type'] ) ) {
+		$query->set( 'post_type', [
+			'post',
+			'page',
+		] );
+	}
+}
+add_action( 'pre_get_posts', 'wmf_remove_profile_from_search' );

--- a/inc/search.php
+++ b/inc/search.php
@@ -13,7 +13,7 @@
  * @return void
  */
 function wmf_remove_profile_from_search( $query ) {
-	if ( $query->is_search() && $query->is_main_query() && ! isset( $_GET['post_type'] ) ) {
+	if ( $query->is_search() && $query->is_main_query() && ! isset( $_GET['post_type'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$query->set( 'post_type', [
 			'post',
 			'page',

--- a/search.php
+++ b/search.php
@@ -50,7 +50,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
-			$query_option = ( isset( $_GET['post_type'][0] ) )
+			$query_option = ( isset( $_GET['post_type'][0] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				? sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				: 'all';
 			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';

--- a/search.php
+++ b/search.php
@@ -63,9 +63,18 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				// Simplest way to get the all types is removing post_type param.
 				if ( $key !== 'all' ) {
 					$href .= '&post_type[]=' . $key;
+					$aria_label = sprintf( __( 'Filter search for %s only', 'shiro' ), $value );
+				} else {
+					$aria_label = sprintf( __( 'Show all search results', 'shiro' ), $value );
 				}
 
-				echo '<a href="' . esc_url( $href ) . '" class="' . esc_attr( $active ) . '">' . esc_html( $value ) . '</a>';
+				printf(
+					'<a href="%1$s" class="search-results__tab %2$s" aria-label="%3$s" title="%3$s">%4$s</a>',
+					esc_url( $href ),
+					esc_attr( $active ),
+					esc_attr( $aria_label ),
+					esc_html( $value )
+				);
 			}
 			?>
 	</div>

--- a/search.php
+++ b/search.php
@@ -50,9 +50,9 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
-			if ( isset( $_GET['post_type'][0] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$query_option = sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			}
+			$query_option = ( isset( $_GET['post_type'][0] ) )
+				? sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				: 'all';
 			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';
 			$selected = esc_attr( $option );
 

--- a/search.php
+++ b/search.php
@@ -28,17 +28,16 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 		$first_result = ( $posts_per_page * $paged ) - $posts_per_page + 1;
 		$last_result = min( $total_results, $wp_query->post_count * $paged );
 		if ( $total_results === 1 ) {
-			$first_result = 1;
-			$last_result  = 1;
+			printf( esc_html__( 'Showing 1 of 1 result', 'shiro' ) );
+		} else {
+			printf(
+				/* translators: 1. first result, 2. last result, 3. total results */
+				esc_html__( 'Showing %1$s - %2$s of %3$s results', 'shiro' ),
+				esc_html( $first_result ),
+				esc_html( $last_result ),
+				esc_html( $total_results )
+			);
 		}
-
-		printf(
-			/* translators: 1. first result, 2. last result, 3. total results */
-			esc_html__( 'Showing %1$s - %2$s of %3$s results', 'shiro' ),
-			esc_html( $first_result ),
-			esc_html( $last_result ),
-			esc_html( $total_results )
-		);
 		?>
 	</div>
 
@@ -50,11 +49,23 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				'page' => 'Pages',
 			];
 
-			$selected = isset( $_GET['post_type'] ) ? esc_attr( array_shift( sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ) ) : 'all';
+			// All is the default option if none is selected, or if the post_type provided isn't in the list.
+			$option = 'all';
+			if ( isset( $_GET['post_type'] ) ) {
+				$option = sanitize_text_field( wp_unslash( array_shift( $_GET['post_type'] ) ) );
+				$option = ( ! array_key_exists( $option, $options ) ) ? 'all' : $option;
+			}
+			$selected = esc_attr( $option );
 
 			foreach ( $options as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
-				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query() . '&post_type[]=' . $key;
+
+				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query();
+				// Simplest way to get the all types is removing post_type param.
+				if ( $key !== 'all' ) {
+					$href .=  '&post_type[]=' . $key;
+				}
+
 				echo '<a href="' . esc_url( $href ) . '" class="' . esc_attr( $active ) . '">' . esc_html( $value ) . '</a>';
 			}
 			?>

--- a/search.php
+++ b/search.php
@@ -50,7 +50,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
-			if ( isset( $_GET['post_type'][0] ) ) {
+			if ( isset( $_GET['post_type'][0] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$query_option = sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			}
 			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';
@@ -81,7 +81,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 					the_post();
 
 					// Render the block for the current post
-					echo WMF\Editor\Blocks\BlogPost\render_block(
+					echo WMF\Editor\Blocks\BlogPost\render_block( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						[ 'post_id' => $post->ID ]
 					);
 				}

--- a/search.php
+++ b/search.php
@@ -6,9 +6,7 @@
  * @package shiro
  */
 
-get_header(); ?>
-
-<?php
+get_header();
 
 $wmf_results_copy = get_theme_mod( 'wmf_search_results_copy', /* translators: 1. search query */ __( 'Search results for %s', 'shiro-admin' ) );
 
@@ -21,34 +19,71 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 
 ?>
 
+<?php if ( have_posts() ) : ?>
+	<div class="search-results__count mw-980">
+		<?php
+			$total_results = $wp_query->found_posts;
+			$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
+			$posts_per_page = get_query_var( 'posts_per_page' );
+			$first_result = ( $posts_per_page * $paged ) - $posts_per_page + 1;
+			$last_result = min( $total_results, $wp_query->post_count * $paged );
+			if ( $total_results === 1 ) {
+				$first_result = 1;
+				$last_result  = 1;
+			}
+			/* translators: 1. first result, 2. last result, 3. total results */
+			printf( __( 'Showing %1$d-%2$d of %3$d results', 'shiro' ), $first_result, $last_result, $total_results );
+		?>
+	</div>
+
+	<div class="search-results__tabs mw-980">
+		<?php
+			$options = [
+				'all' => 'All',
+				'post' => 'News',
+				'page' => 'Pages',
+			];
+
+			$selected = isset( $_GET['post_type'] ) ? esc_attr( array_shift( $_GET['post_type'] ) ) : 'all';
+
+			foreach ( $options as $key => $value ) {
+				$active = $selected === $key ? 'active' : '';
+				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query() . '&post_type[]=' . $key;
+				echo '<a href="' . $href . '" class="' . $active . '">' . $value . '</a>';
+			}
+		?>
+	</div>
+<?php endif; ?>
+
 <div class="mw-980 mod-margin-bottom flex flex-medium news-card-list">
+
 	<div id="search-results" class="card-list-container">
-		<?php if ( have_posts() ) : ?>
-			<?php
-			while ( have_posts() ) :
-				the_post();
 
-				echo WMF\Editor\Blocks\BlogPost\render_block(
-					[ 'post_id' => $post->ID ]
-				);
-			endwhile;
+			<?php
+				if ( have_posts() ) {
+					while ( have_posts() ) {
+						the_post();
+
+						// Render the block for the current post
+						echo WMF\Editor\Blocks\BlogPost\render_block(
+							[ 'post_id' => $post->ID ]
+						);
+					}
+				} else {
+					// If there are no posts, display a "content-none" template
+					get_template_part( 'template-parts/content', 'none' );
+				}
 			?>
+		</div>
+	</div>
 
-			<?php
-		else :
-			get_template_part( 'template-parts/content', 'none' );
+	<div id="pagination">
+		<?php
+		if ( have_posts() ) :
+			get_template_part( 'template-parts/pagination' );
 		endif;
 		?>
 	</div>
-</div>
-
-<div id="pagination">
-	<?php
-	if ( have_posts() ) :
-		get_template_part( 'template-parts/pagination' );
-	endif;
-	?>
-</div>
 
 <?php
 get_footer();

--- a/search.php
+++ b/search.php
@@ -12,7 +12,7 @@ $wmf_results_copy = get_theme_mod( 'wmf_search_results_copy', /* translators: 1.
 
 $template_args = array(
 	/* translators: Query that is currently being searched */
-	'h1_title' => sprintf( __( $wmf_results_copy, 'shiro' ), get_search_query() ),
+	'h1_title' => sprintf( __( $wmf_results_copy, 'shiro' ), get_search_query() ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 );
 
 get_template_part( 'template-parts/header/page-noimage', null, $template_args );
@@ -22,17 +22,23 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 <?php if ( have_posts() ) : ?>
 	<div class="search-results__count mw-980">
 		<?php
-			$total_results = $wp_query->found_posts;
-			$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-			$posts_per_page = get_query_var( 'posts_per_page' );
-			$first_result = ( $posts_per_page * $paged ) - $posts_per_page + 1;
-			$last_result = min( $total_results, $wp_query->post_count * $paged );
-			if ( $total_results === 1 ) {
-				$first_result = 1;
-				$last_result  = 1;
-			}
+		$total_results = $wp_query->found_posts;
+		$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
+		$posts_per_page = get_query_var( 'posts_per_page' );
+		$first_result = ( $posts_per_page * $paged ) - $posts_per_page + 1;
+		$last_result = min( $total_results, $wp_query->post_count * $paged );
+		if ( $total_results === 1 ) {
+			$first_result = 1;
+			$last_result  = 1;
+		}
+
+		printf(
 			/* translators: 1. first result, 2. last result, 3. total results */
-			printf( __( 'Showing %1$d-%2$d of %3$d results', 'shiro' ), $first_result, $last_result, $total_results );
+			esc_html__( 'Showing %1$s - %2$s of %3$s results', 'shiro' ),
+			esc_html( $first_result ),
+			esc_html( $last_result ),
+			esc_html( $total_results )
+		);
 		?>
 	</div>
 
@@ -44,14 +50,14 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				'page' => 'Pages',
 			];
 
-			$selected = isset( $_GET['post_type'] ) ? esc_attr( array_shift( $_GET['post_type'] ) ) : 'all';
+			$selected = isset( $_GET['post_type'] ) ? esc_attr( array_shift( sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ) ) : 'all';
 
 			foreach ( $options as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
 				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query() . '&post_type[]=' . $key;
-				echo '<a href="' . $href . '" class="' . $active . '">' . $value . '</a>';
+				echo '<a href="' . esc_url( $href ) . '" class="' . esc_attr( $active ) . '">' . esc_html( $value ) . '</a>';
 			}
-		?>
+			?>
 	</div>
 <?php endif; ?>
 
@@ -60,19 +66,19 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 	<div id="search-results" class="card-list-container">
 
 			<?php
-				if ( have_posts() ) {
-					while ( have_posts() ) {
-						the_post();
+			if ( have_posts() ) {
+				while ( have_posts() ) {
+					the_post();
 
-						// Render the block for the current post
-						echo WMF\Editor\Blocks\BlogPost\render_block(
-							[ 'post_id' => $post->ID ]
-						);
-					}
-				} else {
-					// If there are no posts, display a "content-none" template
-					get_template_part( 'template-parts/content', 'none' );
+					// Render the block for the current post
+					echo WMF\Editor\Blocks\BlogPost\render_block(
+						[ 'post_id' => $post->ID ]
+					);
 				}
+			} else {
+				// If there are no posts, display a "content-none" template
+				get_template_part( 'template-parts/content', 'none' );
+			}
 			?>
 		</div>
 	</div>

--- a/search.php
+++ b/search.php
@@ -50,7 +50,9 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
-			$query_option = sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['post_type'][0] ) ) {
+				$query_option = sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			}
 			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';
 			$selected = esc_attr( $option );
 
@@ -60,7 +62,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query();
 				// Simplest way to get the all types is removing post_type param.
 				if ( $key !== 'all' ) {
-					$href .=  '&post_type[]=' . $key;
+					$href .= '&post_type[]=' . $key;
 				}
 
 				echo '<a href="' . esc_url( $href ) . '" class="' . esc_attr( $active ) . '">' . esc_html( $value ) . '</a>';

--- a/search.php
+++ b/search.php
@@ -50,11 +50,8 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
-			$option = 'all';
-			if ( isset( $_GET['post_type'] ) ) {
-				$option = sanitize_text_field( wp_unslash( array_shift( $_GET['post_type'] ) ) );
-				$option = ( ! array_key_exists( $option, $options ) ) ? 'all' : $option;
-			}
+			$query_option = sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';
 			$selected = esc_attr( $option );
 
 			foreach ( $options as $key => $value ) {

--- a/search.php
+++ b/search.php
@@ -43,9 +43,9 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 	<div class="search-results__tabs mw-980">
 		<?php
 			$options = [
-				'all' => __( 'All', 'shiro'),
-				'post' => __( 'News', 'shiro'),
-				'page' => __( 'Pages', 'shiro'),
+				'all' => __( 'All', 'shiro' ),
+				'post' => __( 'News', 'shiro' ),
+				'page' => __( 'Pages', 'shiro' ),
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
@@ -58,11 +58,11 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			foreach ( $options as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
 
-				$href = add_query_arg ('s', get_search_query(), home_url( '/' ) );
+				$href = add_query_arg( 's', get_search_query(), home_url( '/' ) );
 
 				// Simplest way to get the all types is not adding post_type param filter.
 				if ( $key !== 'all' ) {
-					$href = add_query_arg ('post_type[]', $key, $href );
+					$href = add_query_arg( 'post_type[]', $key, $href );
 
 					/* translators: post type, i.e., News or Pages */
 					$aria_label = sprintf( __( 'Filter search for %s only', 'shiro' ), $value );

--- a/search.php
+++ b/search.php
@@ -63,6 +63,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				// Simplest way to get the all types is removing post_type param.
 				if ( $key !== 'all' ) {
 					$href .= '&post_type[]=' . $key;
+					/* translators: post type, i.e., News or Pages */
 					$aria_label = sprintf( __( 'Filter search for %s only', 'shiro' ), $value );
 				} else {
 					$aria_label = sprintf( __( 'Show all search results', 'shiro' ), $value );

--- a/search.php
+++ b/search.php
@@ -11,8 +11,7 @@ get_header();
 $wmf_results_copy = get_theme_mod( 'wmf_search_results_copy', /* translators: 1. search query */ __( 'Search results for %s', 'shiro-admin' ) );
 
 $template_args = array(
-	/* translators: Query that is currently being searched */
-	'h1_title' => sprintf( __( $wmf_results_copy, 'shiro' ), get_search_query() ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+	'h1_title' => sprintf( $wmf_results_copy, get_search_query() ),
 );
 
 get_template_part( 'template-parts/header/page-noimage', null, $template_args );
@@ -44,9 +43,9 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 	<div class="search-results__tabs mw-980">
 		<?php
 			$options = [
-				'all' => 'All',
-				'post' => 'News',
-				'page' => 'Pages',
+				'all' => __( 'All', 'shiro'),
+				'post' => __( 'News', 'shiro'),
+				'page' => __( 'Pages', 'shiro'),
 			];
 
 			// All is the default option if none is selected, or if the post_type provided isn't in the list.
@@ -59,10 +58,12 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			foreach ( $options as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
 
-				$href = esc_url( home_url( '/' ) ) . '?s=' . get_search_query();
-				// Simplest way to get the all types is removing post_type param.
+				$href = add_query_arg ('s', get_search_query(), home_url( '/' ) );
+
+				// Simplest way to get the all types is not adding post_type param filter.
 				if ( $key !== 'all' ) {
-					$href .= '&post_type[]=' . $key;
+					$href = add_query_arg ('post_type[]', $key, $href );
+
 					/* translators: post type, i.e., News or Pages */
 					$aria_label = sprintf( __( 'Filter search for %s only', 'shiro' ), $value );
 				} else {


### PR DESCRIPTION
This pull request intends to improve search results page.

## Related ticket
https://github.com/humanmade/Wikimedia/issues/763

## Tasks
- [x] Fix bug on block render to make search results to show up
- [x] Set order parameter to 1) relevancy 2) date descending
- [x] Add controls for users to filter search results (all / news (posts) / pages)
- [x] Make search controls accessible
- [x] Added line separator between each result
- [x] Fix bug not displaying H1 title "_Search results for <search-query>_" when querying for some specific words
- [x] Add message "_Showing x - y of z results_"
