### PR TITLE
[#767] Prevent error accessing unregistered meta value

### DIFF
--- a/assets/src/editor/plugins/hide-page-title-controls/index.js
+++ b/assets/src/editor/plugins/hide-page-title-controls/index.js
@@ -6,8 +6,20 @@ import { __ } from '@wordpress/i18n';
 import useMeta from '../../hooks/useMeta';
 
 /**
- * Adds a toggle control to hide the page title, in the post status box.
+ * Render a toggle control to hide the page title.
  */
+function TogglePageTitleControl( { label, help } ) {
+	const [ hideTitle, setHideTitle ] = useMeta( 'wmf_hide_title', false );
+
+	return (
+		<ToggleControl
+			label={ label }
+			help={ help }
+			checked={ hideTitle }
+			onChange={ setHideTitle }
+		/>
+	);
+}
 
 /**
  * The name of this editor plugin. Required.
@@ -23,19 +35,15 @@ export const settings = {
 	render: function Render() {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 
-		const [ hideTitle, setHideTitle ] = useMeta( 'wmf_hide_title', false );
-
 		if ( postType !== 'page' ) {
 			return;
 		}
 
 		return  (
 			<PluginPostStatusInfo>
-				<ToggleControl
+				<TogglePageTitleControl
 					label={ __( 'Hide this page title', 'shiro-admin' ) }
 					help={ __( 'Use this option to avoid redundant titles, for example if the page hero contains its title.', 'shiro-admin' ) }
-					checked={ hideTitle }
-					onChange={ setHideTitle }
 				/>
 			</PluginPostStatusInfo>
 		);

--- a/assets/src/editor/plugins/hide-page-title-controls/index.js
+++ b/assets/src/editor/plugins/hide-page-title-controls/index.js
@@ -36,7 +36,7 @@ export const settings = {
 		const postType = select( 'core/editor' ).getCurrentPostType();
 
 		if ( postType !== 'page' ) {
-			return;
+			return null;
 		}
 
 		return  (


### PR DESCRIPTION
Fixes an error which shows up in the post-new.php screen for any post types other than pages.

The "wmf_hide_title" value issn't registered for any post types other than Pages, so trying to access it with the `useMeta` hook was throwing errors for any users who weren't super-admins. This moves the hook inside a component which is conditionally rendered, so that it isn't being accessed where it shouldn't be.