### PR TITLE
#799: Fix Safari broken image on Banner Block

### DIFF
--- a/assets/src/sass/helpers/mixins/_mixins-layout.scss
+++ b/assets/src/sass/helpers/mixins/_mixins-layout.scss
@@ -22,7 +22,6 @@
 
 @mixin absolute-full-cover() {
 	bottom: 0;
-	content: "";
 	display: block;
 	height: 100%;
 	left: 0;


### PR DESCRIPTION
Removing this PR as there is a typo on the branch name that can lead to a confusion. Opened https://github.com/wikimedia/shiro-wordpress-theme/pull/41 to replace it.