### PR TITLE
#799: Fix Banner Block broken image on Safari

### DIFF
--- a/assets/src/sass/blocks/_banner.scss
+++ b/assets/src/sass/blocks/_banner.scss
@@ -33,6 +33,8 @@
 
 	&__image {
 		@include absolute-full-cover();
+		content: unset !important; // Overwritting content property from the mixin - see #799
+
 		object-fit: cover;
 	}
 


### PR DESCRIPTION
## Description
This PR intends to fix a bug hiding the Banner Block image on Safari.

## Related ticket
https://github.com/humanmade/Wikimedia/issues/799

## Solution found
I found that the empty `content` property has no effect when applied for an image - it's projected to be used among `::before` and `::after` pseudo-elements. Adding a `!important` as there is a chance of the mixin include having precedence over the explicit declared property.

## Bug details

### Image added on Block Editor
![image](https://user-images.githubusercontent.com/90911997/232803219-6f12d992-4bf9-4d1f-9618-c026de55fff2.png)

### Image missing on Safari
![image](https://user-images.githubusercontent.com/90911997/232803060-57af3e9a-57f0-40d2-aff4-0e8dd5fa60c1.png)

## Testing instructions

Edit and Preview this page using Safari:
https://wikimediafoundation-org-develop.go-vip.co/wp-admin/post.php?post=71245&action=edit

The image added should not be missing.