### PR TITLE
#797: Fix for content language taxonomy filter

### DIFF
--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -183,7 +183,7 @@ function wmf_filter_posts_by_content_language( WP_Query $query ) : void {
 	$query->set( 'tax_query', $tax_query );
 }
 
-add_filter( 'pre_get_posts', 'wmf_filter_posts_by_content_language' );
+add_action( 'pre_get_posts', 'wmf_filter_posts_by_content_language' );
 add_action( 'wp_insert_post', 'wmf_add_default_content_language' );
 add_action( 'admin_init', 'wmf_create_current_language_term' );
 add_action( 'init', 'wmf_register_content_language_taxonomy' );

--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -145,8 +145,8 @@ function wmf_add_default_content_language( int $post_ID ): void {
  */
 function wmf_filter_posts_by_content_language( WP_Query $query ) : void {
 
-	// Don't filter the admin or singular pages.
-	if ( is_admin() || is_singular() ) {
+	// Don't filter the admin, singular pages or non-main queries.
+	if ( is_admin() || ! $query->is_main_query() || is_singular() ) {
 		return;
 	}
 


### PR DESCRIPTION
This PR intends to add a filter to ensure that  posts having different `current-language` taxonomy are not displayed on the post listings.

## Related ticket 
https://github.com/humanmade/Wikimedia/issues/797

## Context
In order to allow creating content in languages that don't have a dedicated site, we register "Content Language" as a taxonomy which can be set on a per-post basis. This allows for individual posts relevant to communities not otherwise served by the blog to be translated and associated with the original post in the same way that MultiLingual Press handles associating content between different language sites.

## Bug description
If a translation post is created and the taxonomy `content-language` is set to a language different than the main language term, currently set to `en_US`.

![image](https://user-images.githubusercontent.com/90911997/233226399-78ebe451-f957-486c-a9f0-1c34bdd7bbcd.png)

## Solution found
I decided to add a filter to remove from the queries posts which has `content-language` taxonomy set different than the main language term. That is making the undesired posts to disappear from the post listings. Posts which has `en_US` and a different `content-language` taxonomy, such as `pt_BR`, which is incorrect, also disappears from the listings.
