### PR TITLE
779: Permit assets to be loaded from first available manifest

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -129,7 +129,7 @@ function wmf_scripts() {
 	wp_enqueue_script( 'shiro-svg4everybody', get_template_directory_uri() . '/assets/dist/svg4everybody.min.js', array( 'jquery' ), '0.0.1', true );
 	wp_enqueue_script( 'shiro-script', get_template_directory_uri() . '/assets/dist/scripts.min.js', array( 'jquery', 'shiro-svg4everybody' ), $script_version, true );
 	Asset_Loader\enqueue_asset(
-		\WMF\Assets\get_manifest_path(),
+		\WMF\Assets\get_manifest_path( 'shiro.js' ),
 		'shiro.js',
 		[
 			'dependencies' => [],

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -8,15 +8,29 @@ namespace WMF\Assets;
 use Asset_Loader\Manifest;
 
 /**
- * Get the active asset manifest path.
+ * Get the array of valid theme build manifests.
  *
- * Uses dev server if running, otherwise loads from production asset manifest.
+ * @return array
+ */
+function get_manifests() : array {
+	return [
+		get_template_directory() . '/assets/dist/development-asset-manifest.json',
+		get_template_directory() . '/assets/dist/production-asset-manifest.json',
+	];
+}
+
+/**
+ * Check through the available manifests to find the first which includes the
+ * target asset. This allows some assets to be loaded from a running DevServer
+ * while others load from production files on disk.
  *
  * @return string|null
  */
-function get_manifest_path() {
-	return Manifest\get_active_manifest( [
-		get_template_directory() . '/assets/dist/development-asset-manifest.json',
-		get_template_directory() . '/assets/dist/production-asset-manifest.json',
-	] );
+function get_manifest_path( $target_asset ) {
+	foreach ( get_manifests() as $manifest_path ) {
+		$asset_uri = Manifest\get_manifest_resource( $manifest_path, $target_asset );
+		if ( ! empty( $asset_uri ) ) {
+			return $manifest_path;
+		}
+	}
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -24,6 +24,7 @@ function get_manifests() : array {
  * target asset. This allows some assets to be loaded from a running DevServer
  * while others load from production files on disk.
  *
+ * @param string $target_asset Desired asset within the manifest.
  * @return string|null
  */
 function get_manifest_path( $target_asset ) {

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -443,10 +443,8 @@ function is_using_block_editor(): bool {
  * Enqueue assets used only in the block editor.
  */
 function enqueue_block_editor_assets() {
-	$manifest = Assets\get_manifest_path();
-
 	Asset_Loader\enqueue_asset(
-		$manifest,
+		Assets\get_manifest_path( 'editor.js' ),
 		'editor.js',
 		[
 			'dependencies' => [
@@ -477,9 +475,10 @@ function enqueue_block_editor_assets() {
 		)
 	);
 
+	$css_asset = is_rtl() ? 'editor.rtl.css' : 'editor.css';
 	Asset_Loader\enqueue_asset(
-		$manifest,
-		is_rtl() ? 'editor.rtl.css' : 'editor.css',
+		Assets\get_manifest_path( $css_asset ),
+		$css_asset,
 		[
 			'handle' => 'shiro_editor_css',
 		]


### PR DESCRIPTION
This allows assets to be drawn from different manifests depending on what is available. That way it is possible to use the live-reloading dev server while developing blocks alongside previously-built static theme assets, or vice versa, where previously there was no way to load some prod assets while the dev server was running.

This makes the `npm run start:webpack:theme` and `npm run start:webpack:editor` aliases work as expected.