### PR TITLE
#805: Fix Block Editor list item issue after WordPress upgrade

### DIFF
--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -82,6 +82,7 @@ function filter_blocks( $allowed_block_types, $block_editor_context ) {
 		'core/image',
 		'core/heading',
 		'core/list',
+		'core/list-item',
 		'core/table',
 		'core/audio',
 		'core/video',


### PR DESCRIPTION
This PR intends to fix a problem on Block Editor list item.

I found that sinceWordPress 6.1 list items has their own blocks, so I needed to add `core/list-item` to the list of allowed blocks to fix the issue.