### PR TITLE
834: Prefix search params with ? when updating donate button

### DIFF
--- a/assets/src/scripts/modules/donate-buttons.js
+++ b/assets/src/scripts/modules/donate-buttons.js
@@ -12,7 +12,7 @@ const init = () => {
 		const { search } = link;
 		const params = new URLSearchParams( search );
 		params.set( 'utm_source', object_id );
-		link.href = link.href.replace( search, params.toString() );
+		link.href = link.href.replace( search, `?${ params.toString() }` );
 	} );
 };
 


### PR DESCRIPTION
`URLSearchParams#toString` does not include the leading `?`, so we need to add it back in otherwise this search-replace breaks the href of the link.

For humanmade/wikimedia#834