### PR TITLE
814: Server-render TOC block for third-level items

### DIFF
--- a/assets/src/editor/blocks/table-of-contents/deprecations.js
+++ b/assets/src/editor/blocks/table-of-contents/deprecations.js
@@ -1,0 +1,160 @@
+/**
+ * Handle old versions of this block.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import HeadingLinks from './HeadingLinks';
+
+/**
+ * Original version of ToC block, which rendered JS-side within the editor
+ * and stored the rendered headings list in post content as well as in block
+ * attributes. Transitioned in May 2023 to v2, where the block is entirely
+ * server-rendered in PHP.
+ */
+const v1 = {
+	supports: {
+		inserter: false,
+		multiple: false,
+		reusable: false,
+	},
+	attributes: {
+		headingBlocks: {
+			type: 'array',
+			default: [],
+		},
+	},
+	/**
+	 * Render save of the original v1 table of contents block.
+	 */
+	save( { attributes } ) {
+		const blockProps = useBlockProps.save( {
+			className: 'table-of-contents toc',
+		} );
+
+		return (
+			<>
+				{ attributes.headingBlocks.length > 0 && (
+					<nav
+						className="toc-nav"
+						data-backdrop="inactive"
+						data-dropdown="toc-nav"
+						data-dropdown-content=".toc"
+						data-dropdown-status="uninitialized"
+						data-dropdown-toggle=".toc__button"
+						data-sticky="false"
+						data-toggleable="yes"
+						data-trap="inactive"
+						data-visible="false"
+					>
+						<h2 className="toc__title screen-reader-text">
+							{ __( 'Table of Contents', 'shiro' ) }
+						</h2>
+						<button className="toc__button">
+							<span className="btn-label-a11y">
+								{ __(
+									'Navigate within this page.',
+									'shiro'
+								) }
+							</span>
+							<span className="btn-label-active-item">
+								{ attributes.headingBlocks[ 0 ].attributes.content.replace(
+									/(<([^>]+)>)/gi,
+									''
+								) || __( 'Toggle menu', 'shiro' ) }
+							</span>
+						</button>
+						<ul { ...blockProps }>
+							<HeadingLinks
+								blocks={ attributes.headingBlocks }
+								edit={ false }
+							/>
+						</ul>
+					</nav>
+				) }
+			</>
+		);
+	},
+};
+
+/**
+ * A variant of the v1 markup where some posts are saved with aria labels
+ * on the button element within the list markup.
+ */
+const v1WithAriaOnButton = {
+	supports: {
+		inserter: false,
+		multiple: false,
+		reusable: false,
+	},
+	attributes: {
+		headingBlocks: {
+			type: 'array',
+			default: [],
+		},
+	},
+	/**
+	 * Render save of the original v1 table of contents block.
+	 */
+	save( { attributes } ) {
+		const blockProps = useBlockProps.save( {
+			className: 'table-of-contents toc',
+		} );
+
+		console.log( 'trying old save' ); // eslint-disable-line
+
+		return (
+			<>
+				{ attributes.headingBlocks.length > 0 && (
+					<nav
+						className="toc-nav"
+						data-backdrop="inactive"
+						data-dropdown="toc-nav"
+						data-dropdown-content=".toc"
+						data-dropdown-status="uninitialized"
+						data-dropdown-toggle=".toc__button"
+						data-sticky="false"
+						data-toggleable="yes"
+						data-trap="inactive"
+						data-visible="false"
+					>
+						<h2 className="toc__title screen-reader-text">
+							{ __( 'Table of Contents', 'shiro' ) }
+						</h2>
+						<button
+							aria-expanded="false"
+							className="toc__button"
+							hidden
+						>
+							<span className="btn-label-a11y">
+								{ __(
+									'Navigate within this page.',
+									'shiro'
+								) }
+							</span>
+							<span className="btn-label-active-item">
+								{ attributes.headingBlocks[ 0 ].attributes.content.replace(
+									/(<([^>]+)>)/gi,
+									''
+								) || __( 'Toggle menu', 'shiro' ) }
+							</span>
+						</button>
+						<ul { ...blockProps }>
+							<HeadingLinks
+								blocks={ attributes.headingBlocks }
+								edit={ false }
+							/>
+						</ul>
+					</nav>
+				) }
+			</>
+		);
+	},
+};
+
+export default [
+	v1,
+	v1WithAriaOnButton,
+];

--- a/assets/src/editor/blocks/table-of-contents/index.js
+++ b/assets/src/editor/blocks/table-of-contents/index.js
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import deprecated from './deprecations';
 import HeadingLinks from './HeadingLinks';
 import { getHeadingBlocks, setHeadingAnchors } from './tocHelpers';
 
@@ -34,6 +35,9 @@ export const name = 'shiro/toc',
 				default: false,
 			},
 		},
+
+		// Support automatic transitioning from old block version.
+		deprecated,
 
 		/**
 		 * Render edit of the table of contents block.
@@ -148,57 +152,9 @@ export const name = 'shiro/toc',
 
 		/**
 		 * Render save of the table of contents block.
-		 */
-		save: function SaveTableOfContentsBlock( { attributes } ) {
-			const blockProps = useBlockProps.save( {
-				className: 'table-of-contents toc',
-			} );
-
-			return (
-				<>
-					{ attributes.headingBlocks.length > 0 && (
-						<nav
-							className="toc-nav"
-							data-backdrop="inactive"
-							data-dropdown="toc-nav"
-							data-dropdown-content=".toc"
-							data-dropdown-status="uninitialized"
-							data-dropdown-toggle=".toc__button"
-							data-sticky="false"
-							data-toggleable="yes"
-							data-trap="inactive"
-							data-visible="false"
-						>
-							<h2 className="toc__title screen-reader-text">
-								{ __( 'Table of Contents', 'shiro' ) }
-							</h2>
-							<button
-								aria-expanded="false"
-								className="toc__button"
-								hidden
-							>
-								<span className="btn-label-a11y">
-									{ __(
-										'Navigate within this page.',
-										'shiro'
-									) }
-								</span>
-								<span className="btn-label-active-item">
-									{ attributes.headingBlocks[ 0 ].attributes.content.replace(
-										/(<([^>]+)>)/gi,
-										''
-									) || __( 'Toggle menu', 'shiro' ) }
-								</span>
-							</button>
-							<ul { ...blockProps }>
-								<HeadingLinks
-									blocks={ attributes.headingBlocks }
-									edit={ false }
-								/>
-							</ul>
-						</nav>
-					) }
-				</>
-			);
+		*/
+		save() {
+			// Server-rendered.
+			return null;
 		},
 	};

--- a/assets/src/editor/blocks/table-of-contents/index.js
+++ b/assets/src/editor/blocks/table-of-contents/index.js
@@ -1,4 +1,5 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { Panel, PanelBody, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -27,6 +28,10 @@ export const name = 'shiro/toc',
 			headingBlocks: {
 				type: 'array',
 				default: [],
+			},
+			includeH3s: {
+				type: 'boolean',
+				default: false,
 			},
 		},
 
@@ -100,6 +105,26 @@ export const name = 'shiro/toc',
 
 			return (
 				<>
+					<InspectorControls>
+						<Panel header={ __( 'Structure', 'shiro-admin' ) } initialOpen>
+							<PanelBody>
+								<ToggleControl
+									label={ __( 'Third-level headings', 'shiro-admin' ) }
+									help={
+										attributes.includeH3s
+											? __( 'Include h3 headings.', 'shiro-admin' )
+											: __( 'Omit h3 headings.', 'shiro-admin' )
+									}
+									checked={ attributes.includeH3s }
+									onChange={ () => {
+										setAttributes( {
+											includeH3s: ! attributes.includeH3s,
+										} );
+									} }
+								/>
+							</PanelBody>
+						</Panel>
+					</InspectorControls>
 					{ attributes.headingBlocks.length > 0 ? (
 						<nav className="toc-nav">
 							<ul { ...blockProps }>

--- a/assets/src/editor/blocks/table-of-contents/index.js
+++ b/assets/src/editor/blocks/table-of-contents/index.js
@@ -152,7 +152,7 @@ export const name = 'shiro/toc',
 
 		/**
 		 * Render save of the table of contents block.
-		*/
+		 */
 		save() {
 			// Server-rendered.
 			return null;

--- a/assets/src/sass/blocks/_table-of-contents.scss
+++ b/assets/src/sass/blocks/_table-of-contents.scss
@@ -193,13 +193,7 @@
 	}
 
 	&__nested &__link {
-		padding-left: rem(44);
-
-		&--active,
-		&--active:hover {
-			background-color: inherit;
-			color: $wmui-color-base0;
-		}
+		padding-left: rem(40);
 	}
 
 	&__section {

--- a/assets/src/scripts/modules/toc-nav.js
+++ b/assets/src/scripts/modules/toc-nav.js
@@ -13,6 +13,16 @@ const headerHeight = document
 	.getBoundingClientRect()[ 'height' ];
 
 /**
+ * Does this tag node name correspond to a supported level of header?
+ *
+ * @param {string} tagName Node name (H2, LI, etc).
+ * @returns {boolean} Whether this node is an H2 or H3.
+ */
+function isHeaderNode( tagName ) {
+	return /^H[2-3]$/.test( tagName );
+}
+
+/**
  * @returns {IntersectionObserver} A configured observer, ready to observe.
  *
  * @param {object} options The options to use with the observer.
@@ -66,20 +76,20 @@ function processEntry( entry ) {
 			nav.dataset.toggleable = 'yes';
 			nav.dataset.sticky = 'no';
 		}
-	} else if ( [ 'H2', 'P', 'LI' ].includes( target.tagName ) ) {
+	} else if ( [ 'H2', 'H3', 'P', 'LI' ].includes( target.tagName ) ) {
 		if (
 			isIntersecting &&
 			intersectionRatio >= 0.5 &&
-			target.tagName === 'H2'
+			isHeaderNode( target.tagName )
 		) {
 			target.dataset.visible = 'yes';
-		} else if ( target.tagName === 'H2' ) {
+		} else if ( isHeaderNode( target.tagName ) ) {
 			target.dataset.visible = 'no';
 		}
 
 		if ( _tocNav.dataset.observeScroll === 'yes' ) {
 			const allH2s = Object.values(
-				_contentColumn.querySelectorAll( 'h2[id]' )
+				_contentColumn.querySelectorAll( 'h2[id],h3[id]' )
 			);
 			const firstH2 = allH2s.filter(
 				h2 => h2.dataset.visible === 'yes'
@@ -297,7 +307,7 @@ function initializeTocNav() {
 				rootMargin: headerHeight + 'px 0px 0px 0px',
 				threshold: [ 0, 0.25, 0.5, 0.75, 1 ],
 			} );
-			_contentColumn.querySelectorAll( 'h2, p, li' ).forEach( _el => {
+			_contentColumn.querySelectorAll( 'h2, h3, p, li' ).forEach( _el => {
 				_contentColumn.observer.observe( _el );
 			} );
 		}
@@ -314,7 +324,7 @@ function initializeTocNav() {
 				processActiveLink( activeTocItem, hash );
 			}
 
-			// Turn on sticky nav so that it can do it's own detections.
+			// Turn on sticky nav so that it can do its own detections.
 			if ( _tocNav.dataset.toggleable === 'no' ) {
 				_tocNav.dataset.sticky = 'yes';
 			}

--- a/functions.php
+++ b/functions.php
@@ -270,6 +270,7 @@ require get_template_directory() . '/inc/editor/blocks/read-more-categories.php'
 require get_template_directory() . '/inc/editor/blocks/share-article.php';
 require get_template_directory() . '/inc/editor/blocks/profile.php';
 require get_template_directory() . '/inc/editor/blocks/profile-list.php';
+require get_template_directory() . '/inc/editor/blocks/toc.php';
 require get_template_directory() . '/inc/editor/has-blocks-column.php';
 require get_template_directory() . '/inc/editor/intro.php';
 require get_template_directory() . '/inc/editor/patterns.php';
@@ -297,6 +298,7 @@ WMF\Editor\Blocks\ReadMoreCategories\bootstrap();
 WMF\Editor\Blocks\ShareArticle\bootstrap();
 WMF\Editor\Blocks\Profile\bootstrap();
 WMF\Editor\Blocks\ProfileList\bootstrap();
+WMF\Editor\Blocks\TOC\bootstrap();
 WMF\Editor\Patterns\bootstrap();
 
 /**

--- a/inc/editor/blocks/linked-toc-item.php
+++ b/inc/editor/blocks/linked-toc-item.php
@@ -49,7 +49,7 @@ function update_toc_item( string $block_content, array $block ) {
  *
  * @return string Nested toc column or passed in block content.
  */
-function maybe_create_nested_toc( string $block_content, array $block, $instance ) {
+function maybe_create_nested_toc( string $block_content, array $block ) {
 	// Only apply nesting if we find a toc block.
 	if ( 'shiro/toc' !== $block['blockName'] ) {
 		return $block_content;

--- a/inc/editor/blocks/linked-toc-item.php
+++ b/inc/editor/blocks/linked-toc-item.php
@@ -18,74 +18,6 @@ const PLACEHOLDER = '%MENU_PLACEHOLDER%';
 function bootstrap() {
 	add_filter( 'render_block', __NAMESPACE__ . '\\update_toc_item', 10, 2 );
 	add_filter( 'render_block', __NAMESPACE__ . '\\maybe_create_nested_toc', 20, 3 );
-	// // add_filter( 'pre_render_block', function( $pre_render ) {
-	// // 	echo '<div style="padding-left: 1rem">';
-	// // 	return $pre_render;
-	// // }, 5);
-	// // add_filter( 'pre_render_block', function( $content ) {
-	// // 	echo '</div>';
-	// // 	return $content;
-	// // }, 30);
-	// // add_filter( 'pre_render_block', function( $pre_render, $parsed_block ) {
-	// // 	echo '<pre>' . $parsed_block['blockName'] . '</pre>';
-	// // 	return $pre_render;
-	// // }, 5, 2 );
-	// add_filter( 'render_block', function( $block_content, $block ) {
-	// 	// echo '<pre>' . $block['blockName'] . '</pre>';
-	// 	if ( 'core/heading' !== $block['blockName'] ) {
-	// 		return $block_content;
-	// 	}
-	// 	echo '<pre>' . wp_json_encode( escape_json_content( $block ), JSON_PRETTY_PRINT ) . '</pre>';
-	// 	return $block_content;
-	// }, 5, 2 );
-
-	$headings = [];
-	add_filter( 'render_block', function( $block_content, $block ) use ( &$headings ) {
-		if ( 'core/heading' === $block['blockName'] ) {
-			// We need to get the items class and href, so using a domdoc to confidently locate them.
-			$heading_block_doc = new \DOMDocument();
-			$heading_block_doc->loadHTML( $block_content, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD );
-			if ( $heading_block_doc->hasChildNodes() ) {
-				$heading = $heading_block_doc->childNodes[0];
-				$headings[] = [
-					'nodeName' => $heading->nodeName,
-					'anchor' => $heading->getAttribute( 'id' ),
-					'content' => trim( wp_kses( $block_content, [] ) ),
-				];
-			}
-
-		}
-		return $block_content;
-	}, 10, 2 );
-	add_filter( 'render_block', function( $block_content, $block ) {
-		if ( 'shiro/toc' === $block['blockName'] ) {
-			return PLACEHOLDER;
-		}
-		return $block_content;
-	}, 30, 2 );
-	add_filter( 'the_content', function( $content ) use ( &$headings ) {
-		if ( empty( $headings ) || strpos( $content, PLACEHOLDER ) === false ) {
-			return $content;
-		}
-		ob_start();
-		?>
-		<ul class="wp-block-shiro-toc table-of-contents toc">
-			<?php foreach ( $headings as $idx => $heading ) : ?>
-			<?php if ( $heading['nodeName'] === 'h2' && ( $headings[ $idx - 1 ]['nodeName'] ?? 'h2' ) !== 'h2' ) : ?>
-			</ul></li>
-			<?php endif; ?>
-			<li class="toc__item">
-			<a class="toc__link" href="#<?php echo esc_attr( $heading['anchor'] ); ?>"><?php echo esc_html( $heading['content'] ); ?></a>
-			<?php if ( ( $headings[ $idx + 1 ]['nodeName'] ?? 'h2' ) !== 'h2' ) : ?>
-			<ul>
-			<?php else :?>
-			</li>
-			<?php endif; ?>
-			<?php endforeach; ?>
-		</ul>
-		<?php
-		return str_replace( PLACEHOLDER, (string) ob_get_clean(), $content );
-	} );
 }
 
 /**
@@ -146,21 +78,6 @@ function maybe_create_nested_toc( string $block_content, array $block, $instance
 	if ( 'shiro/toc' !== $block['blockName'] ) {
 		return $block_content;
 	}
-
-	// echo '<p><strong>properties</strong></p>';
-	// echo '<pre>' . print_r( array_keys( (array) $instance ), true ) . '</pre>';
-	// echo '<p><strong>Block content</strong></p>';
-	// echo '<pre>' . esc_html( preg_replace( "/></", ">\n<", $block_content ) ) . '</pre>';
-	// echo '<p><strong>Block attrs</strong></p>';
-	// echo '<pre>' . wp_json_encode( escape_json_content( $block ), JSON_PRETTY_PRINT ) . '</pre>';
-	// // wp_die( sprintf( '<p><strong>properties</strong></p><pre>%s</pre><p><strong>public</strong></p><pre>%s</pre>', print_r( array_keys( (array) $instance ), true ), print_r( array_keys( (array) get_object_vars( $instance ) ), true ) ) );
-
-	// return '';'
-
-	// $post = get_post();
-	// if ( ! empty( $post ) ) {
-	// 	$headings = parse_blocks
-	// }
 
 	// Check if a parent page exists.
 	$post_parent = get_post_parent();

--- a/inc/editor/blocks/linked-toc-item.php
+++ b/inc/editor/blocks/linked-toc-item.php
@@ -39,30 +39,6 @@ function update_toc_item( string $block_content, array $block ) {
 	return is_null( $helper ) ? $block_content : $helper['content'];
 }
 
-function escape_json_content($data) {
-	if (is_array($data)) {
-		foreach ($data as $key => $value) {
-			if ( $key === 'innerContent' ) {
-				$data[$key] = array_map( 'esc_html', $data[$key] );
-			} elseif (in_array($key, [ 'post_content', 'innerHTML', 'content', 'originalContent' ], true ) ) {
-				$data[$key] = esc_html($value);
-			} elseif (is_array($value) || is_object($value)) {
-				$data[$key] = escape_json_content($value);
-			}
-		}
-	} elseif (is_object($data)) {
-		foreach ($data as $key => $value) {
-			if ($key === "content" || $key === "originalContent") {
-				$data->$key = esc_html($value);
-			} elseif (is_array($value) || is_object($value)) {
-				$data->$key = escape_json_content($value);
-			}
-		}
-	}
-
-	return $data;
-}
-
 /**
  * If a table of contents block is found, check to see if there is a linked table of contents in the parent block. If so,
  * add the linked toc block as the parent in the toc column with the contents of the table of contents block as a child under

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -66,9 +66,9 @@ function bootstrap() {
 			<li class="toc__item">
 				<a class="toc__link" href="#<?php echo esc_attr( $heading['anchor'] ); ?>"><?php echo esc_html( $heading['content'] ); ?></a>
 				<?php if ( count( $heading['children'] ) ) : ?>
-				<ul>
+				<ul class="toc toc__nested">
 					<?php foreach ( $heading['children'] as $nested_heading ) : ?>
-					<li class="toc__item toc__item--child">
+					<li class="toc__item">
 						<a class="toc__link" href="#<?php echo esc_attr( $nested_heading['anchor'] ); ?>">
 							<?php echo esc_html( $nested_heading['content'] ); ?>
 						</a>

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -148,9 +148,6 @@ function render_toc_block( string $block_content, array $block ) : string {
 	}
 
 	$headings = get_headings_from_post_content( get_post()->post_content ?? '' );
-
-	$ret = '<pre>' . print_r( $headings, true ) . '</pre>';
-
 	$max_depth = ( $block['attrs']['includeH3s'] ?? false ) ? 'h3' : 'h2';
 	$headings = headings_to_nested_list( $headings, $max_depth );
 

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Additional functionality for the shiro/toc block.
+ *
+ * This block is defined as a client side block in JS. This is additional functionality when rendering the block.
+ *
+ * @package shiro
+ */
+
+namespace WMF\Editor\Blocks\TOC;
+
+const BLOCK_NAME = 'shiro/toc';
+const PLACEHOLDER = '%MENU_PLACEHOLDER%';
+
+/**
+ * Bootstrap this block functionality.
+ */
+function bootstrap() {
+	$headings = [];
+	add_filter( 'render_block', function( $block_content, $block ) use ( &$headings ) {
+		if ( 'core/heading' === $block['blockName'] ) {
+			// We need to get the items class and href, so using a domdoc to confidently locate them.
+			$heading_block_doc = new \DOMDocument();
+			$heading_block_doc->loadHTML( $block_content, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD );
+			if ( $heading_block_doc->hasChildNodes() ) {
+				$heading = $heading_block_doc->childNodes[0];
+				$headings[] = [
+					'nodeName' => $heading->nodeName,
+					'anchor' => $heading->getAttribute( 'id' ),
+					'content' => trim( wp_kses( $block_content, [] ) ),
+				];
+			}
+
+		}
+		return $block_content;
+	}, 10, 2 );
+
+	add_filter( 'render_block', function( $block_content, $block ) {
+		if ( 'shiro/toc' === $block['blockName'] ) {
+			return preg_replace( '/<ul[^>]+class="wp-block-shiro-toc.*<\/ul>/', PLACEHOLDER, $block_content );
+		}
+		return $block_content;
+	}, 30, 2 );
+
+	add_filter( 'the_content', function( $content ) use ( &$headings ) {
+		if ( empty( $headings ) || strpos( $content, PLACEHOLDER ) === false ) {
+			return $content;
+		}
+		ob_start();
+		?>
+		<ul class="wp-block-shiro-toc table-of-contents toc">
+			<?php foreach ( $headings as $idx => $heading ) : ?>
+			<?php if ( $heading['nodeName'] === 'h2' && ( $headings[ $idx - 1 ]['nodeName'] ?? 'h2' ) !== 'h2' ) : ?>
+			</ul></li>
+			<?php endif; ?>
+			<li class="toc__item">
+			<a class="toc__link" href="#<?php echo esc_attr( $heading['anchor'] ); ?>"><?php echo esc_html( $heading['content'] ); ?></a>
+			<?php if ( ( $headings[ $idx + 1 ]['nodeName'] ?? 'h2' ) !== 'h2' ) : ?>
+			<ul>
+			<?php else :?>
+			</li>
+			<?php endif; ?>
+			<?php endforeach; ?>
+		</ul>
+		<?php
+		return str_replace( PLACEHOLDER, (string) ob_get_clean(), $content );
+	} );
+}

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -151,9 +151,6 @@ function render_toc_block( string $block_content, array $block ) : string {
 	$max_depth = ( $block['attrs']['includeH3s'] ?? false ) ? 'h3' : 'h2';
 	$headings = headings_to_nested_list( $headings, $max_depth );
 
-	// return '<pre>' . print_r( $block, true ) . '</pre>';
-	// return $ret . '<pre>' . print_r( $headings, true ) . '</pre>';
-
 	if ( empty( $headings ) ) {
 		return '';
 	}


### PR DESCRIPTION
<details>

<summary>RFC on this approach, originally included in the description here</summary>

I've baked this down to the reduced POC of my idea to get a direction check from @goldenapples, @MiguelAxcar and possibly @joeleenk. The ticket humanmade/wikimedia#814 wants to be able to support third-level items, and while working on the ticket, I began to explore moving the rendering of the block to the server wholesale. This could decouple the block from a strict hierarchy (which Greg has noted is error prone, in a comment on the original ticket, e.g. you can't use the ToC block within a reusable block) — at the expense of codifying some rules such as "there must only be one on a page."

The way this branch works is,

- Build a list of heading blocks while rendering the post's blocks
- (There's an improvement step that could be added here to rebuild the headings list into a better nested structure, to facilitate better iteration and template code)
- Render a nested list of anchor links pointing to all found headings, and replace the rendered output of the block with that list of headings identified while rendering blocks

If we continued down this road we could remove some of the JS save code, but I want to get feedback on the idea before proceeding. It is working in my local and successfully generates the next level item (CSS and JS needed for best functionality), but I wanted to check whether we had any concerns about the overall proposal or whether it is appropriate to move this to server-side rendering. It feels like a lot less work process-wise to do this on the server than on save, but does mean more "work" during rendering.

</details>

## Support third-level headings in single-page Table of Contents block

This PR refactors the existing ToC block to be server-rendered, and adds support for rendering third-level menu items.

**known issues**

The third-level items are not currently represented in the visual editor. They will display on the frontend if the appropriate option is selected.