### PR TITLE
#825: Fix and improve Customizer page selection interface

### DIFF
--- a/inc/classes/customizer/class-base.php
+++ b/inc/classes/customizer/class-base.php
@@ -67,7 +67,7 @@ abstract class Base {
 		$posts = new WP_Query(
 			array(
 				'post_type'      => 'page',
-				'posts_per_page' => -1,
+				'posts_per_page' => 1000, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 				'orderby'        => 'title',
 				'order'          => 'ASC',
 				'post_status'    => 'publish',
@@ -76,7 +76,7 @@ abstract class Base {
 
 		foreach ( $posts->posts as $post_choice ) {
 			if ( ! empty( $post_choice->post_title ) ) {
-				$page_relative_link = str_replace( home_url(), '', get_permalink( $post_choice->ID ) );
+				$page_relative_link = wp_make_link_relative( get_permalink( $post_choice->ID ) );
 				$choices[ $post_choice->ID ] = $post_choice->post_title . ' (ID ' . $post_choice->ID . ' - ' . $page_relative_link . ')';
 			}
 		}

--- a/inc/classes/customizer/class-base.php
+++ b/inc/classes/customizer/class-base.php
@@ -67,12 +67,17 @@ abstract class Base {
 		$posts = new WP_Query(
 			array(
 				'post_type'      => 'page',
-				'posts_per_page' => 100,
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
 			)
 		);
 
 		foreach ( $posts->posts as $post_choice ) {
-			$choices[ $post_choice->ID ] = $post_choice->post_title;
+			if ( ! empty( $post_choice->post_title ) ) {
+				$page_relative_link = str_replace( home_url(), '', get_permalink( $post_choice->ID ) );
+				$choices[ $post_choice->ID ] = $post_choice->post_title . ' (ID ' . $post_choice->ID . ' - ' . $page_relative_link . ')';
+			}
 		}
 
 		return $choices;

--- a/inc/classes/customizer/class-base.php
+++ b/inc/classes/customizer/class-base.php
@@ -70,6 +70,7 @@ abstract class Base {
 				'posts_per_page' => -1,
 				'orderby'        => 'title',
 				'order'          => 'ASC',
+				'post_status'    => 'publish',
 			)
 		);
 


### PR DESCRIPTION
This PR intends to fix and improve the page selection on Customizer.

### Fixed
- Removed the limit of 100 pages, as Wikimedia currently has more than 150 pages. 

### Improved
I found it very hard finding the pages, full of duplication, so I decided to:
- Sort it alphabetically
- Remove pages with empty title from the list
- Display only published pages
- Add page ID (to give user the capacity of looking for page ID if needed)
- Add page relative URL (as many pages has the same title)

![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/90f0e2c0-11c4-4575-9d37-b25755c9a484)