### PR TITLE
#819: Improve control over page breadcrumb links

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -391,6 +391,12 @@ function wmf_filter_wp_404title( $title_parts ) {
 	return $title_parts;
 }
 
+/**
+ * Custom Page Breadcrumb Links functionality.
+ */
+require get_template_directory() . '/inc/breadcrumb-links.php';
+WMF\Breadcrumb_Links\init();
+
 // Hook into document_title_parts
 add_filter( 'document_title_parts', 'wmf_filter_wp_404title' );
 

--- a/inc/breadcrumb-links.php
+++ b/inc/breadcrumb-links.php
@@ -20,7 +20,7 @@ function init() {
 function add_breadcrumb_link_meta_box() {
 	add_meta_box(
 		'breadcrumb_link_meta_box',
-		'Breadcrumb Link Setup',
+		__( 'Breadcrumb Link Setup', 'shiro-admin' ),
 		__NAMESPACE__ . '\\display_breadcrumb_link_meta_box',
 		'page',
 		'side',
@@ -44,28 +44,28 @@ function display_breadcrumb_link_meta_box( $post ) : void {
 
 	<label for="show_breadcrumb_links">
 		<input type="checkbox" id="show_breadcrumb_links" name="show_breadcrumb_links" <?php checked( $show_breadcrumb_links, 'on' ); ?> />
-		Show Breadcrumb Link
+		<?php esc_html_e( 'Show Breadcrumb Link', 'shiro-admin' ); ?>
 	</label><br /><br />
 
 	<label for="breadcrumb_link_url">
-		Custom Link
+		<?php esc_html_e( 'Custom Link', 'shiro-admin' ); ?>
 		<input
 			type="text"
 			id="breadcrumb_link_url"
 			name="breadcrumb_link_url"
 			value="<?php echo esc_attr( $breadcrumb_link_url ); ?>"
-			placeholder="Leave blank to use default link"
+			placeholder="<?php esc_html_e( 'Leave blank to use default link', 'shiro-admin' ); ?>"
 		/>
 	</label><br /><br />
 
 	<label for="breadcrumb_link_title">
-		Custom Text
+		<?php esc_html_e( 'Custom Text', 'shiro-admin' ); ?>
 		<input
 			type="text"
 			id="breadcrumb_link_title"
 			name="breadcrumb_link_title"
 			value="<?php echo esc_attr( $breadcrumb_link_title ); ?>"
-			placeholder="Leave blank to use default title"
+			placeholder="<?php esc_html_e( 'Leave blank to use default title', 'shiro-admin' ); ?>"
 		/>
 	</label>
 

--- a/inc/breadcrumb-links.php
+++ b/inc/breadcrumb-links.php
@@ -3,15 +3,15 @@
  * Breadcrumb Links
  */
 
- namespace WMF\Breadcrumb_Links;
+namespace WMF\Breadcrumb_Links;
 
- /**
-  * Kick it off.
-  */
- function init() {
-	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\add_breadcrumb_link_meta_box');
+/**
+ * Kick it off.
+ */
+function init() {
+	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\add_breadcrumb_link_meta_box' );
 	add_action( 'save_post', __NAMESPACE__ . '\\save_breadcrumb_link_custom_fields' );
- }
+}
 
 
 /**
@@ -34,12 +34,13 @@ function add_breadcrumb_link_meta_box() {
  *
  * @return void
  */
-function display_breadcrumb_link_meta_box($post) : void {
-    $show_breadcrumb_links = get_post_meta( $post->ID, 'show_breadcrumb_links', true );
+function display_breadcrumb_link_meta_box( $post ) : void {
+	$show_breadcrumb_links = get_post_meta( $post->ID, 'show_breadcrumb_links', true );
 	$breadcrumb_link_url = get_post_meta( $post->ID, 'breadcrumb_link_url', true );
 	$breadcrumb_link_title = get_post_meta( $post->ID, 'breadcrumb_link_title', true );
+	?>
 
-    ?>
+	<?php wp_nonce_field( basename( __FILE__ ), 'breadcrumb_link_nonce' ); ?>
 
 	<label for="show_breadcrumb_links">
 		<input type="checkbox" id="show_breadcrumb_links" name="show_breadcrumb_links" <?php checked( $show_breadcrumb_links, 'on' ); ?> />
@@ -68,7 +69,7 @@ function display_breadcrumb_link_meta_box($post) : void {
 		/>
 	</label>
 
-	 <?php
+	<?php
 }
 
 /**
@@ -77,6 +78,10 @@ function display_breadcrumb_link_meta_box($post) : void {
  * @param int $post_id The ID of the post being saved.
  */
 function save_breadcrumb_link_custom_fields( $post_id ) : void {
+	if ( ! isset( $_POST['breadcrumb_link_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['breadcrumb_link_nonce'] ), basename( __FILE__ ) ) ) {
+		return;
+	}
+
 	if ( isset( $_POST['show_breadcrumb_links'] ) ) {
 		update_post_meta( $post_id, 'show_breadcrumb_links', 'on' );
 	} else {

--- a/inc/breadcrumb-links.php
+++ b/inc/breadcrumb-links.php
@@ -54,7 +54,7 @@ function display_breadcrumb_link_meta_box( $post ) : void {
 			id="breadcrumb_link_url"
 			name="breadcrumb_link_url"
 			value="<?php echo esc_attr( $breadcrumb_link_url ); ?>"
-			placeholder="<?php esc_html_e( 'Leave blank to use default link', 'shiro-admin' ); ?>"
+			placeholder="<?php esc_attr_e( 'Leave blank to use default link', 'shiro-admin' ); ?>"
 		/>
 	</label><br /><br />
 
@@ -65,7 +65,7 @@ function display_breadcrumb_link_meta_box( $post ) : void {
 			id="breadcrumb_link_title"
 			name="breadcrumb_link_title"
 			value="<?php echo esc_attr( $breadcrumb_link_title ); ?>"
-			placeholder="<?php esc_html_e( 'Leave blank to use default title', 'shiro-admin' ); ?>"
+			placeholder="<?php esc_attr_e( 'Leave blank to use default title', 'shiro-admin' ); ?>"
 		/>
 	</label>
 

--- a/inc/breadcrumb-links.php
+++ b/inc/breadcrumb-links.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Breadcrumb Links
+ */
+
+ namespace WMF\Breadcrumb_Links;
+
+ /**
+  * Kick it off.
+  */
+ function init() {
+	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\add_breadcrumb_link_meta_box');
+	add_action( 'save_post', __NAMESPACE__ . '\\save_breadcrumb_link_custom_fields' );
+ }
+
+
+/**
+ * Add the breadcrumb_link meta box.
+ */
+function add_breadcrumb_link_meta_box() {
+	add_meta_box(
+		'breadcrumb_link_meta_box',
+		'Breadcrumb Link Setup',
+		__NAMESPACE__ . '\\display_breadcrumb_link_meta_box',
+		'page',
+		'side',
+	);
+}
+
+/**
+ * Display the breadcrumb link meta box.
+ *
+ * @param WP_Post $post The post object.
+ *
+ * @return void
+ */
+function display_breadcrumb_link_meta_box($post) : void {
+    $show_breadcrumb_links = get_post_meta( $post->ID, 'show_breadcrumb_links', true );
+	$breadcrumb_link_url = get_post_meta( $post->ID, 'breadcrumb_link_url', true );
+	$breadcrumb_link_title = get_post_meta( $post->ID, 'breadcrumb_link_title', true );
+
+    ?>
+
+	<label for="show_breadcrumb_links">
+		<input type="checkbox" id="show_breadcrumb_links" name="show_breadcrumb_links" <?php checked( $show_breadcrumb_links, 'on' ); ?> />
+		Show Breadcrumb Link
+	</label><br /><br />
+
+	<label for="breadcrumb_link_url">
+		Custom Link
+		<input
+			type="text"
+			id="breadcrumb_link_url"
+			name="breadcrumb_link_url"
+			value="<?php echo esc_attr( $breadcrumb_link_url ); ?>"
+			placeholder="Leave blank to use default link"
+		/>
+	</label><br /><br />
+
+	<label for="breadcrumb_link_title">
+		Custom Text
+		<input
+			type="text"
+			id="breadcrumb_link_title"
+			name="breadcrumb_link_title"
+			value="<?php echo esc_attr( $breadcrumb_link_title ); ?>"
+			placeholder="Leave blank to use default title"
+		/>
+	</label>
+
+	 <?php
+}
+
+/**
+ * Save the breadcrumb_link meta when the post is saved.
+ *
+ * @param int $post_id The ID of the post being saved.
+ */
+function save_breadcrumb_link_custom_fields( $post_id ) : void {
+	if ( isset( $_POST['show_breadcrumb_links'] ) ) {
+		update_post_meta( $post_id, 'show_breadcrumb_links', 'on' );
+	} else {
+		update_post_meta( $post_id, 'show_breadcrumb_links', 'off' );
+	}
+
+	if ( isset( $_POST['breadcrumb_link_url'] ) ) {
+		update_post_meta( $post_id, 'breadcrumb_link_url', sanitize_text_field( $_POST['breadcrumb_link_url'] ) );
+	}
+
+	if ( isset( $_POST['breadcrumb_link_title'] ) ) {
+		update_post_meta( $post_id, 'breadcrumb_link_title', sanitize_text_field( $_POST['breadcrumb_link_title'] ) );
+	}
+}

--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -24,13 +24,25 @@ while ( have_posts() ) {
 	);
 
 	if ( $show_title ) {
-		$parent_page = wp_get_post_parent_id( get_the_ID() );
-
 		$template_args = array(
-			'h4_link'  => ! empty( $parent_page ) ? get_the_permalink( $parent_page ) : '',
-			'h4_title' => ! empty( $parent_page ) ? get_the_title( $parent_page ) : '',
 			'h1_title' => get_the_title(),
 		);
+
+		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
+		if ( $breadcrumb_link_switch ) {
+			$parent_page = wp_get_post_parent_id( get_the_ID() );
+
+			$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
+			$breadcrumb_link_title = ( ! empty( $breadcrumb_link_custom_title ) ) ? $breadcrumb_link_custom_title : get_the_title( $parent_page );
+
+			$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
+			$breakcrumb_link = ( ! empty( $breadcrumb_link_custom_url ) ) ? $breadcrumb_link_custom_url : get_the_permalink( $parent_page );
+
+			$template_args = array(
+				'h4_link'  => $breakcrumb_link,
+				'h4_title' => $breadcrumb_link_title,
+			);
+		}
 
 		get_template_part( 'template-parts/header/page', 'noimage', $template_args );
 	} else {

--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -24,9 +24,9 @@ while ( have_posts() ) {
 	);
 
 	if ( $show_title ) {
-		$template_args = array(
+		$template_args = [
 			'h1_title' => get_the_title(),
-		);
+		];
 
 		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
 		if ( $breadcrumb_link_switch ) {
@@ -38,10 +38,8 @@ while ( have_posts() ) {
 			$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
 			$breakcrumb_link = ( ! empty( $breadcrumb_link_custom_url ) ) ? $breadcrumb_link_custom_url : get_the_permalink( $parent_page );
 
-			$template_args = array(
-				'h4_link'  => $breakcrumb_link,
-				'h4_title' => $breadcrumb_link_title,
-			);
+			$template_args['h4_link'] = $breakcrumb_link;
+			$template_args['h4_title'] = $breadcrumb_link_title;
 		}
 
 		get_template_part( 'template-parts/header/page', 'noimage', $template_args );


### PR DESCRIPTION
This PR intends to add a custom setting on page edit controls to allow more control over page breadcrumb links.

### What has changed
- Add "Breadcrumb Links" settings section on page editor
- Allow user to show or hide breadcrumbs for particular pages
- Allow user to set default breadcrumb link text
- Allow user to set default breadcrumb link url

## Test instructions
- Edit a page
- Change parameters on "Breadcrumb Link" section
- View the page and see it reflected

## Screenshots

### Admin interface
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/e7cbbc46-9e05-42fa-adee-8e5ac3ae4b71)

### Frontend
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/fbb86384-d8ad-4cb9-baf6-19953055a1bf)

### Related ticket
https://github.com/humanmade/Wikimedia/issues/819