### PR TITLE
#819: Breadcrumb links for classic editor pages

### DIFF
--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -39,7 +39,7 @@ while ( have_posts() ) {
 		 * 3. 'off' - set to no
 		 */
 		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-		if ( $breadcrumb_link_switch === 'on') {
+		if ( $breadcrumb_link_switch === 'on' ) {
 			$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
 			$breadcrumb_link_title = ( ! empty( $breadcrumb_link_custom_title ) ) ? $breadcrumb_link_custom_title : get_the_title( $parent_page );
 
@@ -48,7 +48,7 @@ while ( have_posts() ) {
 
 			$template_args['h4_link'] = $breakcrumb_link;
 			$template_args['h4_title'] = $breadcrumb_link_title;
-		} elseif ( $breadcrumb_link_switch === 'off' ) {
+		} elseif ( $breadcrumb_link_switch === 'off' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
 			// Does nothing.
 		} elseif ( $breadcrumb_link_switch === '' ) {
 			// Default behavior.

--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -28,10 +28,18 @@ while ( have_posts() ) {
 			'h1_title' => get_the_title(),
 		];
 
-		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-		if ( $breadcrumb_link_switch ) {
-			$parent_page = wp_get_post_parent_id( get_the_ID() );
+		$parent_page = wp_get_post_parent_id( get_the_ID() );
 
+		/**
+		 * Breadcrumb link switch
+		 *
+		 * Possible values of the switch:
+		 * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
+		 * 2. 'on' - set to yes
+		 * 3. 'off' - set to no
+		 */
+		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
+		if ( $breadcrumb_link_switch === 'on') {
 			$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
 			$breadcrumb_link_title = ( ! empty( $breadcrumb_link_custom_title ) ) ? $breadcrumb_link_custom_title : get_the_title( $parent_page );
 
@@ -40,6 +48,12 @@ while ( have_posts() ) {
 
 			$template_args['h4_link'] = $breakcrumb_link;
 			$template_args['h4_title'] = $breadcrumb_link_title;
+		} elseif ( $breadcrumb_link_switch === 'off' ) {
+			// Does nothing.
+		} elseif ( $breadcrumb_link_switch === '' ) {
+			// Default behavior.
+			$template_args['h4_link'] = ! empty( $parent_page ) ? get_the_permalink( $parent_page ) : '';
+			$template_args['h4_title'] = ! empty( $parent_page ) ? get_the_title( $parent_page ) : '';
 		}
 
 		get_template_part( 'template-parts/header/page', 'noimage', $template_args );

--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -15,6 +15,8 @@ get_header();
 while ( have_posts() ) {
 	the_post();
 
+	$template_args = [];
+
 	$blocks = parse_blocks( get_post()->post_content );
 	$first_block = $blocks[0]['blockName'];
 	$show_title = (
@@ -24,38 +26,43 @@ while ( have_posts() ) {
 	);
 
 	if ( $show_title ) {
-		$template_args = [
-			'h1_title' => get_the_title(),
-		];
+		$template_args['h1_title'] = get_the_title();
+	}
 
-		$parent_page = wp_get_post_parent_id( get_the_ID() );
+	/**
+	 * Breadcrumb link switch
+	 *
+	 * Possible values of the switch:
+	 * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
+	 * 2. 'on' - set to yes
+	 * 3. 'off' - set to no
+	 */
+	$parent_page = wp_get_post_parent_id( get_the_ID() );
+	$show_breadcrumb = false;
+	$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
+	if ( $breadcrumb_link_switch === 'on' ) {
+		$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
+		$breadcrumb_link_title = ( ! empty( $breadcrumb_link_custom_title ) ) ? $breadcrumb_link_custom_title : get_the_title( $parent_page );
 
-		/**
-		 * Breadcrumb link switch
-		 *
-		 * Possible values of the switch:
-		 * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
-		 * 2. 'on' - set to yes
-		 * 3. 'off' - set to no
-		 */
-		$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-		if ( $breadcrumb_link_switch === 'on' ) {
-			$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
-			$breadcrumb_link_title = ( ! empty( $breadcrumb_link_custom_title ) ) ? $breadcrumb_link_custom_title : get_the_title( $parent_page );
+		$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
+		$breakcrumb_link = ( ! empty( $breadcrumb_link_custom_url ) ) ? $breadcrumb_link_custom_url : get_the_permalink( $parent_page );
 
-			$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
-			$breakcrumb_link = ( ! empty( $breadcrumb_link_custom_url ) ) ? $breadcrumb_link_custom_url : get_the_permalink( $parent_page );
+		$template_args['h4_link'] = $breakcrumb_link;
+		$template_args['h4_title'] = $breadcrumb_link_title;
 
-			$template_args['h4_link'] = $breakcrumb_link;
-			$template_args['h4_title'] = $breadcrumb_link_title;
-		} elseif ( $breadcrumb_link_switch === 'off' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
-			// Does nothing.
-		} elseif ( $breadcrumb_link_switch === '' ) {
-			// Default behavior.
-			$template_args['h4_link'] = ! empty( $parent_page ) ? get_the_permalink( $parent_page ) : '';
-			$template_args['h4_title'] = ! empty( $parent_page ) ? get_the_title( $parent_page ) : '';
+		$show_breadcrumb = true;
+	} elseif ( $breadcrumb_link_switch === 'off' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
+		// Does nothing.
+	} elseif ( $breadcrumb_link_switch === '' && $show_title ) {
+		// Default behavior.
+		if ( ! empty( $parent_page ) ) {
+			$template_args['h4_link'] = get_the_permalink( $parent_page );
+			$template_args['h4_title'] = get_the_title( $parent_page );
+			$show_breadcrumb = true;
 		}
+	}
 
+	if ( $show_title || $show_breadcrumb ) {
 		get_template_part( 'template-parts/header/page', 'noimage', $template_args );
 	} else {
 		// Fake header content so we get the same margin before the hero blocks.

--- a/template-parts/header/header-content.php
+++ b/template-parts/header/header-content.php
@@ -44,33 +44,36 @@ if ( ! empty( $h2_title ) xor ! empty( $title ) ) {
 	$single_title = ! empty( $h2_title ) ? $h2_title : $title;
 }
 
-/**
- * Breadcrumb link switch
- *
- * Possible values of the switch:
- * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
- * 2. 'on' - set to yes
- * 3. 'off' - set to no
- */
-$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-if ( $breadcrumb_link_switch === 'on' ) {
-	$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
-	$h4_title = ! empty( $breadcrumb_link_custom_title ) ? $breadcrumb_link_custom_title : $h4_title;
+if ( is_page() ) {
+	/**
+	 * Page breadcrumb link switch
+	 *
+	 * Possible values of the switch, inserted on edit page screen:
+	 * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
+	 * 2. 'on' - set to yes
+	 * 3. 'off' - set to no
+	 */
+	$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
+	if ( $breadcrumb_link_switch === 'on' ) {
+		$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
+		$h4_title = ! empty( $breadcrumb_link_custom_title ) ? $breadcrumb_link_custom_title : $h4_title;
 
-	$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
-	$h4_link = ! empty( $breadcrumb_link_custom_url ) ? $breadcrumb_link_custom_url : $h4_link;
-} elseif ( $breadcrumb_link_switch === 'off' ) {
-	$h4_link = '';
-	$h4_title = '';
-	?>
-	<h2 class="h4 eyebrow">
-		&nbsp;
-	</h2>
-	<?php
-} elseif ( $breadcrumb_link_switch === '' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
-	// Don't do anything, page wasn't yet edited with this component on the page.
-	// Breadcumb link will be displayed with default values.
+		$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
+		$h4_link = ! empty( $breadcrumb_link_custom_url ) ? $breadcrumb_link_custom_url : $h4_link;
+	} elseif ( $breadcrumb_link_switch === 'off' ) {
+		$h4_link = '';
+		$h4_title = '';
+		?>
+		<h2 class="h4 eyebrow">
+			&nbsp;
+		</h2>
+		<?php
+	} elseif ( $breadcrumb_link_switch === '' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
+		// Don't do anything, page wasn't yet edited with this component on the page.
+		// Breadcumb link will be displayed with default values.
+	}
 }
+
 ?>
 
 <div class="header-content">

--- a/template-parts/header/header-content.php
+++ b/template-parts/header/header-content.php
@@ -53,7 +53,6 @@ if ( ! empty( $h2_title ) xor ! empty( $title )) {
  * 3. 'off' - set to no
  */
 $breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-//var_dump($breadcrumb_link_switch);exit;
 if ( $breadcrumb_link_switch === 'on') {
 	$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
 	$h4_title = ! empty( $breadcrumb_link_custom_title ) ? $breadcrumb_link_custom_title : $h4_title;
@@ -68,7 +67,7 @@ if ( $breadcrumb_link_switch === 'on') {
 		&nbsp;
 	</h2>
 	<?php
-} elseif ( $breadcrumb_link_switch == '' ) {
+} elseif ( $breadcrumb_link_switch === '' ) {
 	// Don't do anything, page wasn't yet edited with this component on the page.
 	// Breadcumb link will be displayed with default values.
 }

--- a/template-parts/header/header-content.php
+++ b/template-parts/header/header-content.php
@@ -21,15 +21,15 @@ $meta                 = ! empty( $page_header_data['page_meta'] ) ? $page_header
 $allowed_tags         = wp_kses_allowed_html( 'post' );
 $allowed_tags['time'] = true;
 $button = ! empty( get_post_meta( get_the_ID(), 'intro_button', true ) ) ? get_post_meta( get_the_ID(), 'intro_button', true ) : '';
-$extra_height_class = empty($button['title']) ? '' : 'ungrid-extra-height';
+$extra_height_class = empty( $button['title'] ) ? '' : 'ungrid-extra-height';
 $wmf_homedonate_button = get_theme_mod( 'wmf_homedonate_button', __( 'Donate now', 'shiro-admin' ) );
 $wmf_homedonate_uri    = get_theme_mod( 'wmf_homedonate_uri', '#' );
 $wmf_homedonate_intro    = get_theme_mod( 'wmf_homedonate_intro', 'Protect and sustain Wikipedia' );
 $wmf_homedonate_secure    = get_theme_mod( 'wmf_homedonate_secure', 'SECURE DONATIONS' );
 $wmf_emergency_message    = get_theme_mod( 'wmf_emergency_message', '' );
-$wmf_header_link_href	= get_theme_mod( 'wmf_header_link_href', '' );
-$wmf_header_link_aria_label	= get_theme_mod( 'wmf_header_link_aria_label', '' );
-$wmf_alt_header_image_url = get_theme_mod( 'wmf_alt_header_image_url', '');
+$wmf_header_link_href     = get_theme_mod( 'wmf_header_link_href', '' );
+$wmf_header_link_aria_label = get_theme_mod( 'wmf_header_link_aria_label', '' );
+$wmf_alt_header_image_url = get_theme_mod( 'wmf_alt_header_image_url', '' );
 
 
 $image            = ! empty( $page_header_data['image'] ) ? $page_header_data['image'] : '';
@@ -40,7 +40,7 @@ $wmf_translation_selected = get_theme_mod( 'wmf_selected_translation_copy', __( 
 $wmf_translations         = wmf_get_translations();
 
 $single_title = '';
-if ( ! empty( $h2_title ) xor ! empty( $title )) {
+if ( ! empty( $h2_title ) xor ! empty( $title ) ) {
 	$single_title = ! empty( $h2_title ) ? $h2_title : $title;
 }
 
@@ -53,7 +53,7 @@ if ( ! empty( $h2_title ) xor ! empty( $title )) {
  * 3. 'off' - set to no
  */
 $breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
-if ( $breadcrumb_link_switch === 'on') {
+if ( $breadcrumb_link_switch === 'on' ) {
 	$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
 	$h4_title = ! empty( $breadcrumb_link_custom_title ) ? $breadcrumb_link_custom_title : $h4_title;
 
@@ -67,7 +67,7 @@ if ( $breadcrumb_link_switch === 'on') {
 		&nbsp;
 	</h2>
 	<?php
-} elseif ( $breadcrumb_link_switch === '' ) {
+} elseif ( $breadcrumb_link_switch === '' ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
 	// Don't do anything, page wasn't yet edited with this component on the page.
 	// Breadcumb link will be displayed with default values.
 }
@@ -97,19 +97,18 @@ if ( $breadcrumb_link_switch === 'on') {
 	<?php if ( is_front_page() ) { ?>
 		<?php if ( ! empty( $title ) ) : ?>
 			<?php if ( ! empty( $wmf_header_link_href ) ) : ?>
-				<a href="<?php echo esc_url($wmf_header_link_href) ?>" aria-label="<?php echo esc_attr($wmf_header_link_aria_label) ?>">
+				<a href="<?php echo esc_url( $wmf_header_link_href ); ?>" aria-label="<?php echo esc_attr( $wmf_header_link_aria_label ); ?>">
 			<?php endif; ?>
 					<div class="header-animation">
-						<div class="header-bg-img" style="<?php if ( !empty($wmf_alt_header_image_url) ) :
-							echo esc_attr('background-image: url("' . get_template_directory_uri() .  $wmf_alt_header_image_url . '")');
-							endif;
-						?>">
+						<div class="header-bg-img" style="<?php if ( ! empty( $wmf_alt_header_image_url ) ) :
+							echo esc_attr( 'background-image: url("' . get_template_directory_uri() . $wmf_alt_header_image_url . '")' );
+							endif;?>">
 
 						</div>
 						<div class="mw-980">
 							<div class="vision_container hero-home">
 								<div class="hero-home__heading-color has-yellow-50-background-color">
-									<?php get_template_part( 'template-parts/header/vision'); ?>
+									<?php get_template_part( 'template-parts/header/vision' ); ?>
 								</div>
 							</div>
 						</div>
@@ -118,10 +117,10 @@ if ( $breadcrumb_link_switch === 'on') {
 				</a>
 			<?php endif; ?>
 		<?php endif; ?>
-        <?php if ( ! empty( $wmf_emergency_message ) ) : ?>
-            <div class="urgent-header rounded center" style="">
-                <?php echo wp_kses( $wmf_emergency_message, $allowed_tags ); ?>
-            </div>
+		<?php if ( ! empty( $wmf_emergency_message ) ) : ?>
+			<div class="urgent-header rounded center" style="">
+				<?php echo wp_kses( $wmf_emergency_message, $allowed_tags ); ?>
+			</div>
 		<?php endif; ?>
 	<?php } ?>
 
@@ -131,8 +130,8 @@ if ( $breadcrumb_link_switch === 'on') {
 			<h1>
 				<?php echo wp_kses( $single_title, array( 'span' => array( 'class' ) ) ); ?>
 			</h1>
-			<?php if ( !empty( $image ) ) { ?>
-				<img src="<?php echo esc_url($image)?>" alt="">
+			<?php if ( ! empty( $image ) ) { ?>
+				<img src="<?php echo esc_url( $image ); ?>" alt="">
 			<?php } ?>
 		<?php } ?>
 
@@ -152,10 +151,10 @@ if ( $breadcrumb_link_switch === 'on') {
 		<?php } ?>
 
 		<!-- h2 and title, with image -->
-		<?php if ( !empty( $image) && !empty($h2_title) && !empty($title)) { ?>
-			<div class="ungrid <?php echo esc_attr($extra_height_class); ?>">
+		<?php if ( ! empty( $image ) && ! empty( $h2_title ) && ! empty( $title ) ) { ?>
+			<div class="ungrid <?php echo esc_attr( $extra_height_class ); ?>">
 				<div class="mw-980">
-					<?php if ( !empty( $image) && !empty($h2_title) && !empty($title)) { ?>
+					<?php if ( ! empty( $image ) && ! empty( $h2_title ) && ! empty( $title ) ) { ?>
 						<div class="flex flex-medium page-landing fifty-fifty">
 							<div class="module-mu w-50p">
 								<h2 class="h2 eyebrow">
@@ -201,8 +200,8 @@ if ( $breadcrumb_link_switch === 'on') {
 					</div>
 					<div class="w-32p">
 						<div>
-                            <?php echo esc_html( $wmf_homedonate_intro ); ?>
-                        </div>
+							<?php echo esc_html( $wmf_homedonate_intro ); ?>
+						</div>
 						<a class="btn btn-blue" href="<?php echo esc_url( $wmf_homedonate_uri ); ?>"><?php echo esc_html( $wmf_homedonate_button ); ?></a>
 						<span class="secure">
 							<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/src/svg/lock.svg" alt="">

--- a/template-parts/header/header-content.php
+++ b/template-parts/header/header-content.php
@@ -43,6 +43,35 @@ $single_title = '';
 if ( ! empty( $h2_title ) xor ! empty( $title )) {
 	$single_title = ! empty( $h2_title ) ? $h2_title : $title;
 }
+
+/**
+ * Breadcrumb link switch
+ *
+ * Possible values of the switch:
+ * 1. '' - meta data from component not set (page wasn't yet edited with this component on the page)
+ * 2. 'on' - set to yes
+ * 3. 'off' - set to no
+ */
+$breadcrumb_link_switch = get_post_meta( get_the_ID(), 'show_breadcrumb_links', true );
+//var_dump($breadcrumb_link_switch);exit;
+if ( $breadcrumb_link_switch === 'on') {
+	$breadcrumb_link_custom_title = get_post_meta( get_the_ID(), 'breadcrumb_link_title', true );
+	$h4_title = ! empty( $breadcrumb_link_custom_title ) ? $breadcrumb_link_custom_title : $h4_title;
+
+	$breadcrumb_link_custom_url = get_post_meta( get_the_ID(), 'breadcrumb_link_url', true );
+	$h4_link = ! empty( $breadcrumb_link_custom_url ) ? $breadcrumb_link_custom_url : $h4_link;
+} elseif ( $breadcrumb_link_switch === 'off' ) {
+	$h4_link = '';
+	$h4_title = '';
+	?>
+	<h2 class="h4 eyebrow">
+		&nbsp;
+	</h2>
+	<?php
+} elseif ( $breadcrumb_link_switch == '' ) {
+	// Don't do anything, page wasn't yet edited with this component on the page.
+	// Breadcumb link will be displayed with default values.
+}
 ?>
 
 <div class="header-content">


### PR DESCRIPTION
An unexpected behaviour was found on the breadcrumb link feature, already pushed to production.

The problem is reported by Greg here:
https://github.com/humanmade/Wikimedia/issues/819#issuecomment-1552170329

As I'm in the end of my allocation to Wikimedia, I'm pushing this draft pull request that potentially address the issues, still with some additional tests neede.

I also addressed a problem that I found: if a page wasn't yet edited with the metabox "_Breadcrumb link_" on it, the value of the metadata `show_breadcrumb_links` will be empty instead of `off`, and my code considering the value as `off`, not displaying the breadcrumb. That is making the breadcrumb links to disappear on all the Wikimedia's block pages until someone edit the page and set the config "_Show Breadcrumb Link_" to `on`.

Greg also asked to change a previous behaviour, showing breadcrumb link in pages where the option "_Show Breadcrumb Link_" was intentionally checked by user even if the first block is `landing-page-hero`, `home-page-hero` or `report-landing-hero`. Hiding the title was kept for this situation.

### Summary of changes
- Added breadcrumb links control do pages done with Classic Editor
- Considering empty meta value of option "_Show Breadcrumb Link_"  (page not edited with component on it) as `on` instead of `off`
- Always display breadcrumb link in pages where the option "_Show Breadcrumb Link_" was intentionally checked by user. In this case, if the first block is `landing-page-hero`, `home-page-hero` or `report-landing-hero` it will keep hiding the title, as it was previously
- Fixed linter warnings for code that I didn't touch, as the whole file was sent to linter after the file edition