### PR TITLE
845: Open and anchor to the selected FAQ item on page load

### DIFF
--- a/assets/src/sass/blocks/_accordion.scss
+++ b/assets/src/sass/blocks/_accordion.scss
@@ -6,6 +6,7 @@
 	border-bottom: 1px solid;
 	overflow: hidden;
 	padding: 14px 20px;
+	scroll-padding-top: $primary-nav-mobile-height;
 
 	&__title {
 		align-items: center;

--- a/assets/src/scripts/block-accordion.js
+++ b/assets/src/scripts/block-accordion.js
@@ -50,6 +50,14 @@ const addAccordionToggleHandlers = item => {
 const initializeAccordionItems = () => {
 	// Hook in click events to each item.
 	[ ...document.querySelectorAll( '.accordion-item' ) ].forEach( item => addAccordionToggleHandlers( item ) );
+
+	if ( document.location.hash ) {
+		const targetNode = document.querySelector( document.location.hash );
+		if ( targetNode && targetNode.closest( '.accordion-item' ) ) {
+			targetNode.closest( '.accordion-item' ).click();
+			targetNode.closest( '.accordion-item' ).scrollIntoView();
+		}
+	}
 };
 
 document.addEventListener( 'DOMContentLoaded', initializeAccordionItems );

--- a/assets/src/scripts/block-accordion.js
+++ b/assets/src/scripts/block-accordion.js
@@ -51,11 +51,19 @@ const initializeAccordionItems = () => {
 	// Hook in click events to each item.
 	[ ...document.querySelectorAll( '.accordion-item' ) ].forEach( item => addAccordionToggleHandlers( item ) );
 
+	// Open and scroll FAQ into view if visiting page with the anchor link for a section.
 	if ( document.location.hash ) {
 		const targetNode = document.querySelector( document.location.hash );
-		if ( targetNode && targetNode.closest( '.accordion-item' ) ) {
-			targetNode.closest( '.accordion-item' ).click();
-			targetNode.closest( '.accordion-item' ).scrollIntoView();
+		const targetedItem = targetNode && targetNode.closest( '.accordion-item' );
+		if ( targetedItem ) {
+			targetedItem.querySelector( 'button' ).click();
+			setTimeout( () => {
+				// scroll-margin-top is not working as expected, possibly due to
+				// the overflow on the accordion item container. Do it in JS.
+				const position = targetedItem.getBoundingClientRect();
+				const headerHeight = document.body.classList.contains( 'admin-bar' ) ? 94 : 62;
+				window.scrollTo( 0, position.top + window.scrollY - headerHeight );
+			} );
 		}
 	}
 };


### PR DESCRIPTION
I tried to solve this with scroll-padding-top, but because the FAQ item is hidden in an overflow container, that rule doesn't seem to take effect. The easiest way to handle this situation is to detect a targeted anchor on page load, and open the container / scroll it into view using JS.