### PR TITLE
788: Add additional security headers

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -567,6 +567,5 @@ function shiro_safe_title( string $title ): void {
 
 /**
  * Disable JetPack Blaze.
- *
  */
 add_filter( 'jetpack_blaze_enabled', '__return_false' );

--- a/functions.php
+++ b/functions.php
@@ -405,6 +405,12 @@ function wmf_filter_wp_404title( $title_parts ) {
 require get_template_directory() . '/inc/breadcrumb-links.php';
 WMF\Breadcrumb_Links\init();
 
+/**
+ * Security related functions
+ */
+require get_template_directory() . '/inc/security.php';
+WMF\Security\init();
+
 // Hook into document_title_parts
 add_filter( 'document_title_parts', 'wmf_filter_wp_404title' );
 

--- a/inc/security.php
+++ b/inc/security.php
@@ -11,11 +11,11 @@ namespace WMF\Security;
  * Booting up the security functionalities.
  */
 function init() {
-	add_action( 'send_headers', __NAMESPACE__ . '\\enable_strict_transport_security' ); // Making sure of HTTPS
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_x_content_type_options' ); // Option of X Content Type
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_referrer_policy' ); // Policy for referrer
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_permissions_policy' ); // Policy for permissions
+	add_action( 'send_headers', __NAMESPACE__ . '\\enable_strict_transport_security' ); // Making sure of HTTPS.
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security.
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_x_content_type_options' ); // Option of X Content Type.
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_referrer_policy' ); // Policy for referrer.
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_permissions_policy' ); // Policy for permissions.
 }
 
 /**
@@ -30,7 +30,37 @@ function enable_strict_transport_security() {
  * Only allowing content of Wikimedia domain.
  */
 function set_content_security_policy() {
-	header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';");
+	/**
+	 * IMPORTANT NOTICE
+	 *
+	 * Because of many errors being watched in the WMF site, the current
+	 * implementation of our Content-Security-Policy (CSP) is having the 'unsafe-inline'
+	 * directive for the scripts and also the styles. This, even resolving the errors,
+	 * is allowing potential Cross-Site Scripting (XSS) attacks.
+	 *
+	 * TODO:
+	 *
+	 * 1. Removal of 'unsafe-inline' directive for scripts and styles: This directive
+	 *    is making less the efficiency of the CSP against attacks of XSS.
+	 *
+	 * 2. Alternatives being proposed:
+	 *
+	 *    a. Using a nonce: This would need adding a nonce unique to each inline script/style tag.
+	 *
+	 *    b. Using a hash: This involves mapping and making hashes for all inline scripts/styles
+	 *       and including these hashes in the CSP as exceptions.
+	 *
+	 * Please make a note that both strategies will demand substantial effort and testing to make
+	 * sure that functionality of site remains not affected.
+	 */
+
+	header( "Content-Security-Policy:
+				default-src 'self';
+				script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com;
+				style-src 'self' 'unsafe-inline';
+				img-src 'self' data:;
+				font-src 'self';
+			" );
 }
 
 /**

--- a/inc/security.php
+++ b/inc/security.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Adding security functions.
+ *
+ * @package wikimedia-contest;
+ */
+
+namespace WMF\Security;
+
+/**
+ * Booting up the security functionalities.
+ */
+function init() {
+	add_action( 'send_headers', __NAMESPACE__ . '\\enable_strict_transport_security' ); // Making sure of HTTPS
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_x_content_type_options' ); // Option of X Content Type
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_referrer_policy' ); // Policy for referrer
+	add_action( 'send_headers', __NAMESPACE__ . '\\set_permissions_policy' ); // Policy for permissions
+}
+
+/**
+ * Functioning for HSTS, requirement of HTTPS for all connections.
+ */
+function enable_strict_transport_security() {
+	header( 'Strict-Transport-Security: max-age=31536000' );
+}
+
+/**
+ * Function for setting strict Policy of Content Security.
+ * Only allowing content of Wikimedia domain.
+ */
+function set_content_security_policy() {
+	header("Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self';");
+}
+
+/**
+ * Setting the X-Content-Type-Options for no sniffing of MIME type.
+ */
+function set_x_content_type_options() {
+	header( 'X-Content-Type-Options: nosniff' );
+}
+
+/**
+ * Function for setting Referrer Policy. No referrer information.
+ */
+function set_referrer_policy() {
+	header( 'Referrer-Policy: no-referrer' );
+}
+
+/**
+ * Finally, function for setting the Permissions Policy.
+ * We're allowing only the fullscreen feature from our domain.
+ */
+function set_permissions_policy() {
+	header( 'Permissions-Policy: fullscreen=(self)' );
+}

--- a/inc/security.php
+++ b/inc/security.php
@@ -54,13 +54,7 @@ function set_content_security_policy() {
 	 * sure that functionality of site remains not affected.
 	 */
 
-	header( "Content-Security-Policy:
-				default-src 'self';
-				script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com;
-				style-src 'self' 'unsafe-inline';
-				img-src 'self' data:;
-				font-src 'self';
-			" );
+	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com; style-src 'self' 'unsafe-inline';	img-src 'self' data:; font-src 'self';" );
 }
 
 /**

--- a/inc/security.php
+++ b/inc/security.php
@@ -55,7 +55,7 @@ function set_content_security_policy() {
 	 */
 
 	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com http://localhost https://localhost http://localhost:8080; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://piwik.wikimedia.org; font-src 'self' data:; connect-src 'self' wss://public-api.wordpress.com;" );
-	header("X-Frame-Options: SAMEORIGIN");
+	header( "X-Frame-Options: SAMEORIGIN" );
 }
 
 /**

--- a/inc/security.php
+++ b/inc/security.php
@@ -54,7 +54,7 @@ function set_content_security_policy() {
 	 * sure that functionality of site remains not affected.
 	 */
 
-	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com; style-src 'self' 'unsafe-inline';	img-src 'self' data:; font-src 'self';" );
+	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com http://localhost https://localhost http://localhost:8080; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://piwik.wikimedia.org; font-src 'self' data:; connect-src 'self' wss://public-api.wordpress.com;" );
 }
 
 /**

--- a/inc/security.php
+++ b/inc/security.php
@@ -55,7 +55,7 @@ function set_content_security_policy() {
 	 */
 
 	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com http://localhost https://localhost http://localhost:8080; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://piwik.wikimedia.org; font-src 'self' data:; connect-src 'self' wss://public-api.wordpress.com;" );
-	header( "X-Frame-Options: SAMEORIGIN" );
+	header( 'X-Frame-Options: SAMEORIGIN' );
 }
 
 /**

--- a/inc/security.php
+++ b/inc/security.php
@@ -55,6 +55,7 @@ function set_content_security_policy() {
 	 */
 
 	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com http://localhost https://localhost http://localhost:8080; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://piwik.wikimedia.org; font-src 'self' data:; connect-src 'self' wss://public-api.wordpress.com;" );
+	header("X-Frame-Options: SAMEORIGIN");
 }
 
 /**


### PR DESCRIPTION
This PR intends to add additional security headers, addressing problems reported by a scan done by `securityheaders.com` on `soundlogo.wikimedia.org`.

### HTTP headers added
- Strict-Transport-Security: Makes browsers to use only HTTPS for communicate, it improve security of data send.
- Content-Security-Policy: It defines sources approved of content that browser can load, it help prevent attacks of Cross-Site Scripting (XSS) and other data injection.
- X-Content-Type-Options: It stop browsers of MIME-sniffing and make it use the declared content-type, reduce risk of drive-by downloads.
- Referrer-Policy: Control how much referrer information (sent via the Referer header) is include with requests, offer control of privacy and data leakage.
- Permissions-Policy: Allow website to specify which browser features and APIs can be used, giving more control over functionality of website.