### PR TITLE
#875: Bugfix profiles page

### DIFF
--- a/template-parts/profiles/role-list.php
+++ b/template-parts/profiles/role-list.php
@@ -11,19 +11,27 @@ if ( empty( $post_list ) ) {
 	return;
 }
 
-foreach ( $post_list as $term_id => $term_data ) :
+foreach ( $post_list as $term_id => $term_data ) {
 	$name        = ! empty( $term_data['name'] ) ? $term_data['name'] : '';
 	$description = term_description( $term_id, 'role' );
 	$button      = get_term_meta( $term_id, 'role_button', true );
-	$executives   = get_term_meta( $term_id, 'role_executive', true );
+	$executives  = get_term_meta( $term_id, 'role_executive', true );
 	$experts     = get_term_meta( $term_id, 'role_experts', true );
 	$term        = get_term( $term_id, 'role' );
 	$term_slug   = $term->slug;
 	$name        = ( is_wp_error( $term ) || empty( $term->parent ) ) ? '' : $name;
 	$class       = 'role__section wysiwyg';
 
-	$executives_title = get_term_meta( $term_id, 'role_executive_title_override', true ) ?: __( 'Department Executive', 'shiro' );
-	$experts_title = get_term_meta( $term_id, 'role_experts_title_override', true ) ?: __( 'Department Experts', 'shiro' );
+	// Avoided using short ternaries
+	$executives_title = get_term_meta( $term_id, 'role_executive_title_override', true );
+	if ( ! $executives_title ) {
+		$executives_title = __( 'Department Executive', 'shiro' );
+	}
+
+	$experts_title = get_term_meta( $term_id, 'role_experts_title_override', true );
+	if ( ! $experts_title ) {
+		$experts_title = __( 'Department Experts', 'shiro' );
+	}
 
 	// If there is only one executive, it needs to be an array, not a string.
 	if ( is_string( $executives ) && ! empty( $executives ) ) {
@@ -50,11 +58,11 @@ foreach ( $post_list as $term_id => $term_data ) :
 	?>
 
 	<?php
-	if ( is_tax( 'role', 'staff-contractors' ) && ! ( empty ( $executives ) && empty( $experts ) ) ) :
+	if ( is_tax( 'role', 'staff-contractors' ) && ! ( empty( $executives ) && empty( $experts ) ) ) {
 		if ( ! empty( $executives ) ) {
 			?>
 		<h3 class="role__staff-title__executive is-style-h4">
-			<?php echo esc_html__( $executives_title ); ?>
+			<?php echo esc_html( $executives_title ); ?>
 		</h3>
 		<ul class="role__staff-list">
 			<?php
@@ -70,13 +78,13 @@ foreach ( $post_list as $term_id => $term_data ) :
 			}
 			?>
 		</ul>
-		<?php
+			<?php
 		}
 
-		if ( ! empty( $experts ) ) :
-		?>
+		if ( ! empty( $experts ) ) {
+			?>
 		<h3 class="role__staff-title__experts is-style-h4">
-			<?php echo esc_html__( $experts_title ); ?>
+			<?php echo esc_html( $experts_title ); ?>
 		</h3>
 		<ul class="role__staff-list">
 			<?php
@@ -92,12 +100,11 @@ foreach ( $post_list as $term_id => $term_data ) :
 			}
 			?>
 		</ul>
-		<?php
-		endif;
-
-	else :
-		if ( ! empty( $term_data ) ) :
-		?>
+			<?php
+		}
+	} else {
+		if ( ! empty( $term_data ) ) {
+			?>
 		<ul class="role__staff-list">
 			<?php
 			foreach ( $term_data['posts'] as $term_data_post_id ) {
@@ -111,37 +118,36 @@ foreach ( $post_list as $term_id => $term_data ) :
 			}
 			?>
 		</ul>
-		<?php endif; ?>
+			<?php
+		}
 
-		<?php if ( ! empty( $term_data['children'] ) ) : ?>
+		if ( ! empty( $term_data['children'] ) ) {
+			?>
 			<div>
 				<?php
-				foreach ( $term_data['children'] as $child_term_id => $child_term_data ) :
+				foreach ( $term_data['children'] as $child_term_id => $child_term_data ) {
 					$name        = ! empty( $child_term_data['name'] ) ? $child_term_data['name'] : '';
 					$description = term_description( $child_term_id, 'role' );
-					?>
 
-					<?php
 					if ( empty( $child_term_data['posts'] ) ) {
 						continue;
 					}
-					?>
 
-					<?php if ( ! empty( $name ) ) : ?>
+					if ( ! empty( $name ) ) : ?>
 					<h3 class="role__staff-title__nested">
 						<?php echo esc_html( $name ); ?>
 					</h3>
 					<?php endif; ?>
 
 					<?php
-					if ( ! empty( $description ) ) :
+					if ( ! empty( $description ) ) {
 						echo wp_kses_post( $description );
-					endif;
+					}
 					?>
 
 					<ul class="role__staff-list">
 						<?php
-						foreach ( $child_term_data['posts'] as $post_id ) :
+						foreach ( $child_term_data['posts'] as $post_id ) {
 							get_template_part(
 								'template-parts/profiles/role',
 								'item',
@@ -149,36 +155,40 @@ foreach ( $post_list as $term_id => $term_data ) :
 									'id' => $post_id,
 								)
 							);
-						endforeach;
+						}
 						?>
 					</ul>
 
-				<?php endforeach; ?>
+					<?php
+				}
+				?>
 			</div>
-		<?php endif; ?>
-	<?php endif; ?>
+			<?php
+		}
+	}
+	?>
 
 	<?php
-	if ( ! empty( $button['link_to_archive'] ) && ! is_tax( 'role', $term_id ) ) :
+	if ( ! empty( $button['link_to_archive'] ) && ! is_tax( 'role', $term_id ) ) {
 		$link_text = ! empty( $button['text'] )
 			? $button['text']
-			: __(
-				sprintf(
-					/* translators: The name of the current taxonomy. */
-					'View full %s team',
-					$name
-				),
-				'shiro'
+			: sprintf(
+				/* translators: The name of the current taxonomy. */
+				__( 'View full %s team', 'shiro' ),
+				$name
 			);
 		$link_url  = ! empty( $button['link'] ) ? $button['link'] : get_term_link( $term_id, 'role' );
-	?>
+		?>
 		<div class="role__read-more">
 			<a href="<?php echo esc_url( $link_url ); ?>" class="arrow-link">
 				<?php echo esc_html( $link_text ); ?>
 			</a>
 		</div>
-	<?php endif; ?>
+		<?php
+	}
+	?>
 
 </section>
 	<?php
-endforeach;
+}
+?>

--- a/template-parts/profiles/role-list.php
+++ b/template-parts/profiles/role-list.php
@@ -15,15 +15,20 @@ foreach ( $post_list as $term_id => $term_data ) :
 	$name        = ! empty( $term_data['name'] ) ? $term_data['name'] : '';
 	$description = term_description( $term_id, 'role' );
 	$button      = get_term_meta( $term_id, 'role_button', true );
-	$executive   = get_term_meta( $term_id, 'role_executive', true );
+	$executives   = get_term_meta( $term_id, 'role_executive', true );
 	$experts     = get_term_meta( $term_id, 'role_experts', true );
 	$term        = get_term( $term_id, 'role' );
 	$term_slug   = $term->slug;
 	$name        = ( is_wp_error( $term ) || empty( $term->parent ) ) ? '' : $name;
 	$class       = 'role__section wysiwyg';
 
-	$executive_title = get_term_meta( $term_id, 'role_executive_title_override', true ) ?: __( 'Department Executive', 'shiro' );
+	$executives_title = get_term_meta( $term_id, 'role_executive_title_override', true ) ?: __( 'Department Executive', 'shiro' );
 	$experts_title = get_term_meta( $term_id, 'role_experts_title_override', true ) ?: __( 'Department Experts', 'shiro' );
+
+	// If there is only one executive, it needs to be an array, not a string.
+	if ( is_string( $executives ) && ! empty( $executives ) ) {
+		$executives = [ $executives ];
+	}
 
 	if ( ! empty( $name ) && ! is_tax( 'role', $term_id ) ) {
 		$class = $class . ' has-h2';
@@ -46,21 +51,26 @@ foreach ( $post_list as $term_id => $term_data ) :
 
 	<?php
 	if ( is_tax( 'role', 'staff-contractors' ) && ! ( empty ( $executives ) && empty( $experts ) ) ) :
-		if ( ! empty( $executive ) ) {
+		if ( ! empty( $executives ) ) {
 			?>
 		<h3 class="role__staff-title__executive is-style-h4">
-			<?php echo esc_html__( $executive_title ); ?>
+			<?php echo esc_html__( $executives_title ); ?>
 		</h3>
+		<ul class="role__staff-list">
+			<?php
+			foreach ( $executives as $executive_id ) {
+				get_template_part(
+					'template-parts/profiles/role',
+					'item',
+					array(
+						'id'   => $executive_id,
+						'role' => 'executive',
+					)
+				);
+			}
+			?>
+		</ul>
 		<?php
-			get_template_part(
-				'template-parts/profiles/role',
-				'item',
-				array(
-					'id'   => $executive,
-					'list' => false,
-					'role' => 'executive',
-				)
-			);
 		}
 
 		if ( ! empty( $experts ) ) :
@@ -147,7 +157,7 @@ foreach ( $post_list as $term_id => $term_data ) :
 			</div>
 		<?php endif; ?>
 	<?php endif; ?>
-	
+
 	<?php
 	if ( ! empty( $button['link_to_archive'] ) && ! is_tax( 'role', $term_id ) ) :
 		$link_text = ! empty( $button['text'] )


### PR DESCRIPTION
This PR intends to fix iterating problems on profiles page.

The code was prepared to display a single executive instead of a list, but it does not match the component used to select executives which is a list of checkboxes, so I fix it to display a list, keeping the same layout.

### Component used to select department executes 
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/948ab2a1-84b4-4b1c-af0b-63f8d7818aa5)
