### PR TITLE
#885: Add "frame-src" directives to Content-Security-Policy header

### DIFF
--- a/inc/security.php
+++ b/inc/security.php
@@ -64,7 +64,7 @@ function set_content_security_policy() {
 		"connect-src 'self' wss://public-api.wordpress.com",
 	];
 
-	header( "Content-Security-Policy: " . implode( '; ', $csp_allowed ) );
+	header( 'Content-Security-Policy: ' . implode( '; ', $csp_allowed ) );
 	header( 'X-Frame-Options: SAMEORIGIN' );
 }
 

--- a/inc/security.php
+++ b/inc/security.php
@@ -54,7 +54,17 @@ function set_content_security_policy() {
 	 * sure that functionality of site remains not affected.
 	 */
 
-	header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://piwik.wikimedia.org; font-src 'self' data:; connect-src 'self' wss://public-api.wordpress.com;" );
+	$csp_allowed = [
+		"default-src 'self'",
+		"script-src 'self' 'unsafe-inline' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080",
+		"frame-src 'self' https://www.youtube.com https://player.vimeo.com",
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' data: https://piwik.wikimedia.org",
+		"font-src 'self' data:",
+		"connect-src 'self' wss://public-api.wordpress.com",
+	];
+
+	header( "Content-Security-Policy: " . implode( '; ', $csp_allowed ) );
 	header( 'X-Frame-Options: SAMEORIGIN' );
 }
 


### PR DESCRIPTION
Adds YouTube and Vimeo domains to the allowed frame sources as specified in the content security policy.