### PR TITLE
#891: Allow scrolling to view all rotating headers in home hero block

### DIFF
--- a/assets/src/editor/blocks/home-page-hero/style.scss
+++ b/assets/src/editor/blocks/home-page-hero/style.scss
@@ -22,9 +22,12 @@
 		}
 
 		&__heading-wrapper {
-			z-index: 1;
-			position: relative;
+			height: 100%;
+			mask: linear-gradient(to bottom, #000 90%, #0000 100%) repeat-x;
+			overflow-y: scroll;
 			padding-top: 4rem;
+			position: relative;
+			z-index: 1;
 		}
 
 		&__heading {


### PR DESCRIPTION
Enables scrolling inside the container which holds the rotating headings in the home-hero block's edit component, so that it's possible to see (and edit) the text if more headings are set than can fit in the block.

Also adds a fade-out at the bottom of the headings wrapper to indicate that there's more content that can be scrolled into view.

![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/665992/566efa63-9c14-476d-8a37-111c4b25dfba)

## TESTING
 
This code is available on the develop site. If you edit the home page at https://wikimediafoundation-org-develop.go-vip.co/wp-admin/post.php?post=10&action=edit and add additional headings to the hero block they should all be visible.