### PR TITLE
#886: Modify search results to add sorting options buttons

### DIFF
--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -1,4 +1,3 @@
-// Group all style customizations for the 2019-2 transparency report together.
 .search-results {
 	&__tabs {
 		border-bottom: 1px solid $wmui-color-base70;
@@ -31,13 +30,10 @@
 			position: relative;
 			float: right;
 
-			button {
-				padding: 10px 20px;
-				cursor: pointer;
-				display: flex;
-				align-items: center;
-				border: none;
-				background: none;
+			@media (max-width: 500px) {
+				right: 0;
+				position: absolute;
+				float: none;
 			}
 
 			.dropdown-icon::before {
@@ -52,10 +48,15 @@
 				right: 0;
 				z-index: 1;
 
+				&.is-visible {
+					display: block;
+				}
+
 				.sort-option {
 					display: block;
 					padding: 10px 20px;
 					text-decoration: none;
+					border-bottom: 1px solid $wmui-color-base70;
 				}
 			}
 		}

--- a/assets/src/sass/content/_search-results.scss
+++ b/assets/src/sass/content/_search-results.scss
@@ -25,6 +25,40 @@
 				font-weight: 800;
 			}
 		}
+
+		&__sort {
+			display: block;
+			position: relative;
+			float: right;
+
+			button {
+				padding: 10px 20px;
+				cursor: pointer;
+				display: flex;
+				align-items: center;
+				border: none;
+				background: none;
+			}
+
+			.dropdown-icon::before {
+				content: '\25BC';
+				margin-left: 10px;
+			}
+
+			.sort-dropdown {
+				display: none;
+				position: absolute;
+				top: 100%;
+				right: 0;
+				z-index: 1;
+
+				.sort-option {
+					display: block;
+					padding: 10px 20px;
+					text-decoration: none;
+				}
+			}
+		}
 	}
 }
 

--- a/assets/src/scripts/search-results-dropdown.js
+++ b/assets/src/scripts/search-results-dropdown.js
@@ -1,0 +1,52 @@
+/**
+ * Initialize the dropdown functionality for the search results.
+ */
+function initializeDropdownFunctionality() {
+	const dropdown = document.querySelector( '.sort-dropdown' );
+	const toggleButton = document.querySelector( '.search-results__tabs__sort button' );
+
+	/**
+	 * Checks if dropdown is visible.
+	 *
+	 * @returns {boolean} true if visible, false otherwise.
+	 */
+	function isDropdownVisible() {
+		return dropdown.classList.contains( 'is-visible' );
+	}
+
+	/**
+	 * Displays the dropdown and update aria.
+	 */
+	function showDropdown() {
+		dropdown.classList.add( 'is-visible' );
+		toggleButton.setAttribute( 'aria-expanded', 'true' );
+	}
+
+	/**
+	 * Hides the dropdown and update aria.
+	 */
+	function hideDropdown() {
+		dropdown.classList.remove( 'is-visible' );
+		toggleButton.setAttribute( 'aria-expanded', 'false' );
+	}
+
+	toggleButton.addEventListener( 'click', function () {
+		if ( isDropdownVisible() ) {
+			hideDropdown();
+		} else {
+			showDropdown();
+		}
+	} );
+
+	// Hide the dropdown if click happened outside.
+	document.addEventListener( 'click', function ( event ) {
+		// Check if the clicked element is the toggleButton or on any of the button descendants.
+		const isToggleButtonOrChildren = toggleButton.contains( event.target ) || event.target === toggleButton;
+
+		if ( ! dropdown.contains( event.target ) && ! isToggleButtonOrChildren ) {
+			hideDropdown();
+		}
+	} );
+}
+
+document.addEventListener( 'DOMContentLoaded', initializeDropdownFunctionality );

--- a/assets/src/scripts/search-results-dropdown.js
+++ b/assets/src/scripts/search-results-dropdown.js
@@ -5,6 +5,11 @@ function initializeDropdownFunctionality() {
 	const dropdown = document.querySelector( '.sort-dropdown' );
 	const toggleButton = document.querySelector( '.search-results__tabs__sort button' );
 
+	// Short-circuit if dropdown or toggleButton is not found.
+	if ( ! dropdown || ! toggleButton ) {
+		return;
+	}
+
 	/**
 	 * Checks if dropdown is visible.
 	 *

--- a/assets/src/scripts/shiro.js
+++ b/assets/src/scripts/shiro.js
@@ -6,6 +6,7 @@ import './block-collapsible-text';
 import './block-hero-home';
 import './modules/donate-buttons';
 import './post-list-filters';
+import './search-results-dropdown';
 import clockBlock from './clock-block';
 import dimensionShim from './modules/dimension-shim';
 import dropdown from './modules/dropdown';

--- a/inc/search.php
+++ b/inc/search.php
@@ -31,19 +31,21 @@ add_action( 'pre_get_posts', 'wmf_restrict_search' );
  * @return void
  */
 function wmf_custom_sort( WP_Query $query ) {
-	if ( $query->is_search() && $query->is_main_query() ) {
-		$order_by = sanitize_text_field( $_GET['orderby'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		switch ( $order_by ) {
-			case 'date':
-				$order_direction = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( $_GET['order'] ) ) : 'DESC';
-				$query->set( 'order', $order_direction );
-				$query->set( 'orderby', 'date' );
-				break;
+	if ( ! $query->is_main_query() || ! $query->is_search() ) {
+		return;
+	}
 
-			default:
-				$query->set( 'orderby', 'relevance' );
-				break;
-		}
+	$order_by = sanitize_text_field( $_GET['orderby'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	switch ( $order_by ) {
+		case 'date':
+			$order_direction = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( $_GET['order'] ) ) : 'DESC'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$query->set( 'order', $order_direction );
+			$query->set( 'orderby', 'date' );
+			break;
+
+		default:
+			$query->set( 'orderby', 'relevance' );
+			break;
 	}
 }
 add_action( 'pre_get_posts', 'wmf_custom_sort' );
@@ -55,8 +57,8 @@ add_action( 'pre_get_posts', 'wmf_custom_sort' );
  * @return string The updated URL.
  */
 function wmf_set_custom_sort_url( $additional_params = [] ) {
-	$current_url = home_url( add_query_arg( NULL, NULL ) );
-	$parsed_url = parse_url( $current_url );
+	$current_url = home_url( add_query_arg( null, null ) );
+	$parsed_url = wp_parse_url( $current_url );
 
 	$current_query_params = [];
 	if ( isset( $parsed_url['query'] ) ) {

--- a/inc/search.php
+++ b/inc/search.php
@@ -23,16 +23,46 @@ function wmf_restrict_search( $query ) {
 add_action( 'pre_get_posts', 'wmf_restrict_search' );
 
 /**
- * Order search by relevance.
+ * Custom sort for search results based on query parameters.
+ * Orders by relevance or date based on the 'orderby' parameter.
+ * If nothing is set, it default to relevance.
  *
- * @param object $query Full WP_Query object.
- *
+ * @param WP_Query $query The WordPress Query instance.
  * @return void
  */
-function wmf_order_search_by_relevance( $query ) {
+function wmf_custom_sort( WP_Query $query ) {
 	if ( $query->is_search() && $query->is_main_query() ) {
-		$query->set( 'orderby', 'relevance' );
-		$query->set( 'order', 'DESC' );
+		$order_by = sanitize_text_field( $_GET['orderby'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		switch ( $order_by ) {
+			case 'date':
+				$order_direction = isset( $_GET['order'] ) ? strtoupper( sanitize_text_field( $_GET['order'] ) ) : 'DESC';
+				$query->set( 'order', $order_direction );
+				$query->set( 'orderby', 'date' );
+				break;
+
+			default:
+				$query->set( 'orderby', 'relevance' );
+				break;
+		}
 	}
 }
-add_action( 'pre_get_posts', 'wmf_order_search_by_relevance' );
+add_action( 'pre_get_posts', 'wmf_custom_sort' );
+
+/**
+ * Get the current URL with merged query parameters.
+ *
+ * @param array $additional_params Additional query parameters to merge.
+ * @return string The updated URL.
+ */
+function wmf_set_custom_sort_url( $additional_params = [] ) {
+	$current_url = home_url( add_query_arg( NULL, NULL ) );
+	$parsed_url = parse_url( $current_url );
+
+	$current_query_params = [];
+	if ( isset( $parsed_url['query'] ) ) {
+		parse_str( $parsed_url['query'], $current_query_params );
+	}
+
+	$merged_query_params = array_merge( $current_query_params, $additional_params );
+	return $parsed_url['path'] . '?' . http_build_query( $merged_query_params );
+}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -553,7 +553,7 @@ function wmf_is_transparency_report_page() {
 		'page-report-section.php',
 		'page-stories.php',
 	);
-	return in_array( get_page_template_slug(), $included_templates, true );
+	return ( ! is_search() ) && in_array( get_page_template_slug(), $included_templates, true );
 }
 
 /**

--- a/search.php
+++ b/search.php
@@ -118,7 +118,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				parse_str( $option['query'], $query_params );
 				$match = true;
 				foreach ( $query_params as $param => $value ) {
-					if ( ! isset( $_GET[ $param ] ) || sanitize_text_field( wp_unslash( $_GET[ $param ] ) ) !== $value ) {
+					if ( ! isset( $_GET[ $param ] ) || sanitize_text_field( wp_unslash( $_GET[ $param ] ) ) !== $value ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 						$match = false;
 						break;
 					}
@@ -145,7 +145,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 						$option_query_params = [];
 						parse_str( $option['query'], $option_query_params );
 						$custom_sort_url = wmf_set_custom_sort_url( $option_query_params );
-					?>
+						?>
 						<a href="<?php echo esc_url( $custom_sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
 							<?php echo esc_html( $option['label'] ); ?>
 						</a>

--- a/search.php
+++ b/search.php
@@ -57,18 +57,22 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				],
 			];
 
-			$options = [
+			/**
+			 * An empty sort_by value means sorting isn't applied for that post_type,
+			 * so the sort dropdown will not be displayed.
+			 */
+			$search_results_tabs = [
 				'all' => [
 					'label' => __( 'All', 'shiro' ),
-					'sort' => 'relevance',
+					'sort_by' => 'relevance',
 				],
 				'post' => [
 					'label' => __( 'News', 'shiro' ),
-					'sort' => 'date-desc',
+					'sort_by' => 'date-desc',
 				],
 				'page' => [
 					'label' => __( 'Pages', 'shiro' ),
-					'sort' => 'relevance',
+					'sort_by' => false, // No sorting option for pages.
 				],
 			];
 
@@ -76,17 +80,17 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$query_option = ( isset( $_GET['post_type'][0] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				? sanitize_text_field( wp_unslash( $_GET['post_type'][0] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				: 'all';
-			$option = array_key_exists( $query_option, $options ) ? $query_option : 'all';
+			$option = array_key_exists( $query_option, $search_results_tabs ) ? $query_option : 'all';
 			$selected = esc_attr( $option );
 
-			foreach ( $options as $key => $value ) {
+			foreach ( $search_results_tabs as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
 
 				$current_url = add_query_arg( 's', get_search_query(), home_url( '/' ) );
 
 				// Add the default sorting option for the current post_type
-				if ( isset( $sorting_options[ $value['sort'] ] ) ) {
-					$sort_query = $sorting_options[ $value['sort'] ]['query'];
+				if ( isset( $sorting_options[ $value['sort_by'] ] ) ) {
+					$sort_query = $sorting_options[ $value['sort_by'] ]['query'];
 					$current_url = add_query_arg( $sort_query, '', $current_url );
 				}
 
@@ -132,27 +136,33 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$current_sort_label = $sorting_options[ $current_sort ]['label'];
 			?>
 
-			<div class="search-results__tabs__sort">
+			<?php if ( ! empty( $search_results_tabs[ $selected ]['sort_by'] ) ) : ?>
 
-				<button aria-haspopup="true" aria-expanded="false">
-					<span>Sort by</span>&nbsp;<span class="selected-sort"><?php echo esc_html( $current_sort_label ); ?></span>
-					<span class="dropdown-icon"></span>
-				</button>
+				<div class="search-results__tabs__sort">
 
-				<div class="sort-dropdown" role="menu">
-					<?php
-					foreach ( $sorting_options as $sort_key => $option ) {
-						$option_query_params = [];
-						parse_str( $option['query'], $option_query_params );
-						$custom_sort_url = wmf_set_custom_sort_url( $option_query_params );
-						?>
-						<a href="<?php echo esc_url( $custom_sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
-							<?php echo esc_html( $option['label'] ); ?>
-						</a>
-					<?php } ?>
+					<?php echo $current_tab; ?>
+
+					<button aria-haspopup="true" aria-expanded="false">
+						<span>Sort by</span>&nbsp;<span class="selected-sort"><?php echo esc_html( $current_sort_label ); ?></span>
+						<span class="dropdown-icon"></span>
+					</button>
+
+					<div class="sort-dropdown" role="menu">
+						<?php
+						foreach ( $sorting_options as $sort_key => $option ) {
+							$option_query_params = [];
+							parse_str( $option['query'], $option_query_params );
+							$custom_sort_url = wmf_set_custom_sort_url( $option_query_params );
+							?>
+							<a href="<?php echo esc_url( $custom_sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
+								<?php echo esc_html( $option['label'] ); ?>
+							</a>
+						<?php } ?>
+					</div>
+
 				</div>
 
-			</div>
+			<?php endif; ?>
 	</div>
 
 <?php endif; ?>

--- a/search.php
+++ b/search.php
@@ -45,15 +45,15 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$sorting_options = [
 				'relevance' => [
 					'query' => 'orderby=relevance',
-					'label' => 'Relevance'
+					'label' => __( 'Relevance', 'shiro' ),
 				],
 				'date-desc' => [
 					'query' => 'orderby=date&order=DESC',
-					'label' => 'Date (newer first)'
+					'label' => __( 'Date (newest)', 'shiro' ),
 				],
 				'date-asc' => [
 					'query' => 'orderby=date&order=ASC',
-					'label' => 'Date (older first)'
+					'label' => __( 'Date (oldest)', 'shiro' ),
 				],
 			];
 
@@ -82,17 +82,17 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			foreach ( $options as $key => $value ) {
 				$active = $selected === $key ? 'active' : '';
 
-				$href = add_query_arg( 's', get_search_query(), home_url( '/' ) );
+				$current_url = add_query_arg( 's', get_search_query(), home_url( '/' ) );
 
 				// Add the default sorting option for the current post_type
 				if ( isset( $sorting_options[ $value['sort'] ] ) ) {
 					$sort_query = $sorting_options[ $value['sort'] ]['query'];
-					$href = add_query_arg( $sort_query, '', $href );
+					$current_url = add_query_arg( $sort_query, '', $current_url );
 				}
 
 				// Simplest way to get the all types is not adding post_type param filter.
 				if ( $key !== 'all' ) {
-					$href = add_query_arg( 'post_type[]', $key, $href );
+					$current_url = add_query_arg( 'post_type[]', $key, $current_url );
 
 					/* translators: post type, i.e., News or Pages */
 					$aria_label = sprintf( __( 'Filter search for %s only', 'shiro' ), $value['label'] );
@@ -102,7 +102,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 
 				printf(
 					'<a href="%1$s" class="search-results__tab %2$s" aria-label="%3$s" title="%3$s">%4$s</a>',
-					esc_url( $href ),
+					esc_url( $current_url ),
 					esc_attr( $active ),
 					esc_attr( $aria_label ),
 					esc_html( $value['label'] )
@@ -113,7 +113,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$current_sort = 'relevance';
 
 			// Check the URL for each sorting option's parameters
-			foreach ( $sorting_options as $sortKey => $option ) {
+			foreach ( $sorting_options as $sort_key => $option ) {
 				$query_params = [];
 				parse_str( $option['query'], $query_params );
 				$match = true;
@@ -124,7 +124,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 					}
 				}
 				if ( $match ) {
-					$current_sort = $sortKey;
+					$current_sort = $sort_key;
 					break;
 				}
 			}
@@ -132,67 +132,35 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$current_sort_label = $sorting_options[ $current_sort ]['label'];
 			?>
 
-			<div class="sort-container">
-				<button class="sort-button" onclick="toggleDropdown()" aria-haspopup="true" aria-expanded="false">
+			<div class="search-results__tabs__sort">
+
+				<button onclick="toggleDropdown()" aria-haspopup="true" aria-expanded="false">
 					<span>Sort by</span>&nbsp;<span class="selected-sort"><?php echo esc_html( $current_sort_label ); ?></span>
 					<span class="dropdown-icon"></span>
 				</button>
+
 				<div class="sort-dropdown" onclick="toggleDropdown()" role="menu">
-					<?php foreach ( $sorting_options as $sortKey => $option ) : ?>
+					<?php foreach ( $sorting_options as $sort_key => $option ) : ?>
 						<?php
 						$sort_url = add_query_arg( $option['query'], $current_url );
 						?>
-						<a href="<?php echo esc_url( $sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sortKey ); ?>" role="menuitem">
+						<a href="<?php echo esc_url( $sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
 							<?php echo esc_html( $option['label'] ); ?>
 						</a>
 					<?php endforeach; ?>
 				</div>
+
 			</div>
-
-			<script>
-				function toggleDropdown() {
-					const dropdown = document.querySelector('.sort-dropdown');
-					dropdown.style.display = (dropdown.style.display === 'none' || dropdown.style.display === '') ? 'block' : 'none';
-				}
-			</script>
-
-		<style type="text/css">
-			.sort-container {
-				display: inline-block;
-				position: relative;
-				float: right;
-			}
-
-			.sort-button {
-				padding: 10px 20px;
-				cursor: pointer;
-				display: flex;
-				align-items: center;
-				border: none;
-				background: none;
-			}
-
-			.dropdown-icon::before {
-				content: '\25BC';
-				margin-left: 10px;
-			}
-
-			.sort-dropdown {
-				display: none;
-				position: absolute;
-				top: 100%;
-				right: 0;
-				z-index: 1;
-			}
-
-			.sort-dropdown .sort-option {
-				display: block;
-				padding: 10px 20px;
-				text-decoration: none;
-			}
-		</style>
-
 	</div>
+
+	<script>
+		function toggleDropdown() {
+			// WIP: This is a temporary place to toggle the dropdown for a POC.
+			const dropdown = document.querySelector('.sort-dropdown');
+			dropdown.style.display = (dropdown.style.display === 'none' || dropdown.style.display === '') ? 'block' : 'none';
+		}
+	</script>
+
 <?php endif; ?>
 
 <div class="mw-980 mod-margin-bottom flex flex-medium news-card-list">

--- a/search.php
+++ b/search.php
@@ -140,8 +140,6 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 
 				<div class="search-results__tabs__sort">
 
-					<?php echo $current_tab; ?>
-
 					<button aria-haspopup="true" aria-expanded="false">
 						<span>Sort by</span>&nbsp;<span class="selected-sort"><?php echo esc_html( $current_sort_label ); ?></span>
 						<span class="dropdown-icon"></span>

--- a/search.php
+++ b/search.php
@@ -31,7 +31,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 		} else {
 			printf(
 				/* translators: 1. first result, 2. last result, 3. total results */
-				esc_html__( 'Showing %1$s - %2$s of %3$s results', 'shiro' ),
+				esc_html__( 'Showing %1$s-%2$s of %3$s results', 'shiro' ),
 				esc_html( $first_result ),
 				esc_html( $last_result ),
 				esc_html( $total_results )
@@ -60,15 +60,15 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 			$options = [
 				'all' => [
 					'label' => __( 'All', 'shiro' ),
-					'sort' => 'relevance'
+					'sort' => 'relevance',
 				],
 				'post' => [
 					'label' => __( 'News', 'shiro' ),
-					'sort' => 'date-desc'
+					'sort' => 'date-desc',
 				],
 				'page' => [
 					'label' => __( 'Pages', 'shiro' ),
-					'sort' => 'relevance'
+					'sort' => 'relevance',
 				],
 			];
 
@@ -109,7 +109,7 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 				);
 			}
 
-			// Default sort option
+			// Default sort option.
 			$current_sort = 'relevance';
 
 			// Check the URL for each sorting option's parameters
@@ -134,32 +134,26 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 
 			<div class="search-results__tabs__sort">
 
-				<button onclick="toggleDropdown()" aria-haspopup="true" aria-expanded="false">
+				<button aria-haspopup="true" aria-expanded="false">
 					<span>Sort by</span>&nbsp;<span class="selected-sort"><?php echo esc_html( $current_sort_label ); ?></span>
 					<span class="dropdown-icon"></span>
 				</button>
 
-				<div class="sort-dropdown" onclick="toggleDropdown()" role="menu">
-					<?php foreach ( $sorting_options as $sort_key => $option ) : ?>
-						<?php
-						$sort_url = add_query_arg( $option['query'], $current_url );
-						?>
-						<a href="<?php echo esc_url( $sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
+				<div class="sort-dropdown" role="menu">
+					<?php
+					foreach ( $sorting_options as $sort_key => $option ) {
+						$option_query_params = [];
+						parse_str( $option['query'], $option_query_params );
+						$custom_sort_url = wmf_set_custom_sort_url( $option_query_params );
+					?>
+						<a href="<?php echo esc_url( $custom_sort_url ); ?>" class="sort-option" data-sort="<?php echo esc_attr( $sort_key ); ?>" role="menuitem">
 							<?php echo esc_html( $option['label'] ); ?>
 						</a>
-					<?php endforeach; ?>
+					<?php } ?>
 				</div>
 
 			</div>
 	</div>
-
-	<script>
-		function toggleDropdown() {
-			// WIP: This is a temporary place to toggle the dropdown for a POC.
-			const dropdown = document.querySelector('.sort-dropdown');
-			dropdown.style.display = (dropdown.style.display === 'none' || dropdown.style.display === '') ? 'block' : 'none';
-		}
-	</script>
 
 <?php endif; ?>
 

--- a/template-parts/pagination.php
+++ b/template-parts/pagination.php
@@ -4,9 +4,8 @@
  *
  * @package shiro
  */
-
-$newer = get_theme_mod( 'wmf_pagination_newer', __( 'Newer', 'shiro-admin' ) );
-$older = get_theme_mod( 'wmf_pagination_older', __( 'Older', 'shiro-admin' ) );
+$newer = get_theme_mod( 'wmf_pagination_newer', __( 'Next', 'shiro-admin' ) );
+$older = get_theme_mod( 'wmf_pagination_older', __( 'Previous', 'shiro-admin' ) );
 
 $previous_arrow = <<<SVG
 <svg fill="none" height="18" viewBox="0 0 12 18" width="12" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m9.75 0-9 9 9 9 1.5-1.5-7.5-7.5 7.5-7.5z" fill="#000" fill-rule="evenodd"/></svg>

--- a/template-parts/pagination.php
+++ b/template-parts/pagination.php
@@ -5,8 +5,8 @@
  * @package shiro
  */
 
-$newer = get_theme_mod( 'wmf_pagination_newer', __( 'Next', 'shiro-admin' ) );
-$older = get_theme_mod( 'wmf_pagination_older', __( 'Previous', 'shiro-admin' ) );
+$newer = get_theme_mod( 'wmf_pagination_newer', __( 'Previous', 'shiro-admin' ) );
+$older = get_theme_mod( 'wmf_pagination_older', __( 'Next', 'shiro-admin' ) );
 
 $previous_arrow = <<<SVG
 <svg fill="none" height="18" viewBox="0 0 12 18" width="12" xmlns="http://www.w3.org/2000/svg"><path clip-rule="evenodd" d="m9.75 0-9 9 9 9 1.5-1.5-7.5-7.5 7.5-7.5z" fill="#000" fill-rule="evenodd"/></svg>

--- a/template-parts/pagination.php
+++ b/template-parts/pagination.php
@@ -4,6 +4,7 @@
  *
  * @package shiro
  */
+
 $newer = get_theme_mod( 'wmf_pagination_newer', __( 'Next', 'shiro-admin' ) );
 $older = get_theme_mod( 'wmf_pagination_older', __( 'Previous', 'shiro-admin' ) );
 
@@ -44,7 +45,7 @@ if ( ! empty( $additional_args ) ) {
 				echo wp_kses_post(
 					paginate_links( $pagination_args )
 				);
-			?>
+				?>
 		</div>
 
 		<div class="pagination__next-page">


### PR DESCRIPTION
## Changes
- Added sort dropdown with mobile responsiveness and positioning adjustments, follow other buttons and tabs design/colors
- Introduced `search-results-dropdown.js` to support dropdown functionality for search results, adding toggle functionality and making click outside of the dropdown to hide the dropdown
- Modified the search sorting mechanism to accept custom sort options from query parameters.
- It now supports ordering by relevance, date in both ascending and descending orders.

## Screenshot
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/d4f6d3a5-e150-4ce1-b050-477f6d5dcd62)

## Testing instructions
- Search for anything on the site
- Check the sort dropdown's appearance and responsiveness
- Test dropdown toggle functionality
- Verify sorting works by relevance, date (newest first), and date (oldest first)
- Ensure that external clicks hide the dropdown

