### PR TITLE
88: Fix JS error blocking execution of unrelated plugin code.

### DIFF
--- a/assets/src/scripts/post-list-filters.js
+++ b/assets/src/scripts/post-list-filters.js
@@ -1,10 +1,16 @@
 /**
- * Toggles the post list filter container.
+ * Set up event handlers to toggle the News section post list filter container, when present.
  *
- * @param {HTMLElement} filterButton - The button used to toggle the filter container.
- * @param {HTMLElement} filterContainer - The filter container.
+ * @param {HTMLElement|null} filterContainer The node containing the filter form.
  */
-const addFilterToggleHandler = ( filterButton, filterContainer ) => {
+const addFilterToggleHandler = filterContainer => {
+	const filterButton = document.querySelector( '.post-list-filter__toggle' );
+
+	if ( ! filterButton || ! filterContainer ) {
+		// No filter controls available.
+		return;
+	}
+
 	/**
 	 * Click event handler for the filter button.
 	 */
@@ -17,14 +23,49 @@ const addFilterToggleHandler = ( filterButton, filterContainer ) => {
 };
 
 /**
+ * Set up event handlers for the News section date filter interface, when present.
+ */
+const addDateFilterHandlers = () => {
+	const resetDateFiltersButton = document.getElementById( 'button-reset-date-filters' );
+	const fromDateInput = document.querySelector( 'input[name="date_from"]' );
+	const toDateInput = document.querySelector( 'input[name="date_to"]' );
+
+	if ( ! resetDateFiltersButton ) {
+		return;
+	}
+
+	resetDateFiltersButton.addEventListener( 'click', () => {
+		resetDateFilters( fromDateInput, toDateInput );
+	} );
+};
+
+/**
  * Resets the date filters.
  *
  * @param {HTMLElement} fromDateInput - The input element for the "from" date.
  * @param {HTMLElement} toDateInput - The input element for the "to" date.
  */
 const resetDateFilters = ( fromDateInput, toDateInput ) => {
-	fromDateInput.value = '';
-	toDateInput.value = '';
+	if ( fromDateInput ) {
+		fromDateInput.value = '';
+	}
+	if ( toDateInput ) {
+		toDateInput.value = '';
+	}
+};
+
+/**
+ * Set up event handlers for post list filtering form submission and reset behavior.
+ *
+ * @param {HTMLElement|null} filterContainer The node containing the filter form.
+ */
+const addFormHandlers = filterContainer => {
+	const form = document.querySelector( '.post-list-filter__form' );
+	const resetFormButton = filterContainer.querySelector( '#button-clear-filters' );
+	resetFormButton.addEventListener( 'click', () => {
+		resetFormFields( form );
+		form.submit();
+	} );
 };
 
 /**
@@ -34,46 +75,41 @@ const resetDateFilters = ( fromDateInput, toDateInput ) => {
  * @returns {void}
  */
 const resetFormFields = form => {
-
 	// Reset search and date inputs.
 	const inputs = form.querySelectorAll( 'input[type="text"], input[type="date"]' );
-	inputs.forEach( input => {
-		input.value = '';
-	} );
+	if ( inputs ) {
+		inputs.forEach( input => {
+			input.value = '';
+		} );
+	}
 
 	// Reset all category checkboxes.
 	const checkboxes = form.querySelectorAll( 'input[type="checkbox"]' );
-	checkboxes.forEach( checkbox => {
-		checkbox.checked = false;
-	} );
+	if ( checkboxes ) {
+		checkboxes.forEach( checkbox => {
+			checkbox.checked = false;
+		} );
+	}
 };
 
 /**
  * Initializes the post list filters functionality.
  */
 const initializePostListFilters = () => {
-
-	// Controls filters container visibility toggle.
-	const filterButton = document.querySelector( '.post-list-filter__toggle' );
 	const filterContainer = document.querySelector( '.post-list-filter__container' );
-	addFilterToggleHandler( filterButton, filterContainer );
 
-	// Controls date filters reset.
-	const resetDateFiltersButton = document.getElementById( 'button-reset-date-filters' );
-	const fromDateInput = document.querySelector( 'input[name="date_from"]' );
-	const toDateInput = document.querySelector( 'input[name="date_to"]' );
-	resetDateFiltersButton.addEventListener( 'click', () => {
-		resetDateFilters( fromDateInput, toDateInput );
-	} );
+	if ( filterContainer ) {
+		// The filtering UI is present: set up event handling.
 
-	// Controls form reset.
-	const form = document.querySelector( '.post-list-filter__form' );
-	const resetFormButton = filterContainer.querySelector( '#button-clear-filters' );
-	resetFormButton.addEventListener( 'click', () => {
-		resetFormFields( form );
-		form.submit();
-	} );
+		// Controls filters container visibility toggle.
+		addFilterToggleHandler( filterContainer );
 
+		// Controls date filters reset.
+		addDateFilterHandlers();
+
+		// Controls form submission and reset.
+		addFormHandlers( filterContainer );
+	}
 };
 
 document.addEventListener( 'DOMContentLoaded', initializePostListFilters );


### PR DESCRIPTION
The filters we introduced in #55 work well, but the code that manages them still runs on pages outside the News section. Because the filter interface doesn't exist on other pages, these `querySelector` calls returned `null`, and attempts to manipulate those null values fail.

This PR slightly refactors the existing code to add guards around the node queries so that we only run code when the corresponding HTML's on the page.

Fixes #88.

**Testing Instructions**

Visit any page other than the News section. No error resembling `TypeError: Cannot read properties of null (reading 'addEventListener')` should appear.