### PR TITLE
Fix: Supress error messages flooding the PHP logs

### DIFF
--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -34,7 +34,10 @@ function get_headings_from_post_content( string $content ) : array {
 	// within PHP rendering code, even once the content is parsed as blocks.
 	// DOMDocument is the most reliable tool to locate the values we want.
 	$heading_block_doc = new DOMDocument();
-	$heading_block_doc->loadHTML( $content );
+	libxml_use_internal_errors(true); // Silence warnings.
+	$content = preg_replace('/<svg(.*?)<\/svg>/is', '', $content); // Remove any SVG content.
+	$heading_block_doc->loadHTML('<?xml encoding="utf-8" ?>' . $content); // Load with UTF-8 encoding.
+	libxml_clear_errors(); // Clear any raised errors.
 	$xpath = new DOMXPath( $heading_block_doc );
 
 	// Query for h2 and h3 elements that have an id attribute.

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -34,9 +34,9 @@ function get_headings_from_post_content( string $content ) : array {
 	// within PHP rendering code, even once the content is parsed as blocks.
 	// DOMDocument is the most reliable tool to locate the values we want.
 	$heading_block_doc = new DOMDocument();
-	libxml_use_internal_errors(true); // Silence warnings.
-	$content = preg_replace('/<svg(.*?)<\/svg>/is', '', $content); // Remove any SVG content.
-	$heading_block_doc->loadHTML('<?xml encoding="utf-8" ?>' . $content); // Load with UTF-8 encoding.
+	libxml_use_internal_errors( true ); // Silence warnings.
+	$content = preg_replace( '/<svg(.*?)<\/svg>/is', '', $content ); // Remove any SVG content.
+	$heading_block_doc->loadHTML( '<?xml encoding="utf-8" ?>' . $content ); // Load with UTF-8 encoding.
 	libxml_clear_errors(); // Clear any raised errors.
 	$xpath = new DOMXPath( $heading_block_doc );
 

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -35,8 +35,7 @@ function get_headings_from_post_content( string $content ) : array {
 	// DOMDocument is the most reliable tool to locate the values we want.
 	$heading_block_doc = new DOMDocument();
 	libxml_use_internal_errors( true ); // Silence warnings.
-	$content = preg_replace( '/<svg(.*?)<\/svg>/is', '', $content ); // Remove any SVG content.
-	$heading_block_doc->loadHTML( '<?xml encoding="utf-8" ?>' . $content ); // Load with UTF-8 encoding.
+	$heading_block_doc->loadHTML( $content );
 	libxml_clear_errors(); // Clear any raised errors.
 	$xpath = new DOMXPath( $heading_block_doc );
 

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -34,9 +34,17 @@ function get_headings_from_post_content( string $content ) : array {
 	// within PHP rendering code, even once the content is parsed as blocks.
 	// DOMDocument is the most reliable tool to locate the values we want.
 	$heading_block_doc = new DOMDocument();
-	libxml_use_internal_errors( true ); // Silence warnings.
+
+	/**
+	 * Temporarily suppress libxml errors. This is a band-aid solution to silence
+	 * warnings when loading HTML content.
+	 *
+	 * @see Issue #907 for planned enhancements to this approach.
+	 */
+	libxml_use_internal_errors( true );
 	$heading_block_doc->loadHTML( $content );
-	libxml_clear_errors(); // Clear any raised errors.
+	libxml_clear_errors(); // Clear any errors that were raised during the loadHTML operation.
+
 	$xpath = new DOMXPath( $heading_block_doc );
 
 	// Query for h2 and h3 elements that have an id attribute.


### PR DESCRIPTION
This PR intends to push a fix for error which are flooding the PHP logs. 

It still needs testing.

```
PHP message: Warning: DOMDocument::loadHTML(): Tag path invalid in Entity, line: 125 in /var/www/wp-content/themes/shiro/inc/editor/blocks/toc.php on line 37 [wikimediafoundation-org-develop.go-vip.co/about/annualreport/] [wp-content/themes/shiro/inc/editor/blocks/toc.php:37 DOMDocument->loadHTML(), wp-content/themes/shiro/inc/editor/blocks/toc.php:152 WMF\Editor\Blocks\TOC\get_headings_from_post_content(), wp-includes/class-wp-hook.php:312 WMF\Editor\Blocks\TOC\render_toc_block(), wp-includes/plugin.php:205 WP_Hook->apply_filters(), wp-includes/class-wp-block.php:293 apply_filters('render_block'), wp-includes/class-wp-block.php:244 WP_Block->render(), wp-includes/class-wp-block.php:244 WP_Block->render(), wp-includes/class-wp-block.php:244 WP_Block->render(), wp-includes/blocks.php:1133 WP_Block->render(), wp-includes/blocks.php:1171 render_block(), wp-includes/class-wp-hook.php:310 do_blocks(), wp-includes/plugin.php:205 WP_Hook->apply_filters(), wp-includes/post-template.php:256 apply_filters('the_content'), wp-content/themes/shiro/template-parts/content-page.php:16 the_content(), wp-includes/template.php:787 require('wp-content/themes/shiro/template-parts/content-page.php'), wp-includes/template.php:720 load_template(), wp-includes/general-template.php:206 locate_template(), wp-content/themes/shiro/page-block-editor.php:76 get_template_part(), wp-includes/template.php:787 require('wp-content/themes/shiro/page-block-editor.php'), wp-includes/template.php:720 load_template(), wp-includes/general-template.php:206 locate_template(), wp-content/themes/shiro/page.php:18 get_template_part(), wp-includes/template-loader.php:106 include('wp-content/themes/shiro/page.php'), wp-blog-header.php:19 require_once('wp-includes/template-loader.php'), index.php:17 require('wp-blog-header.php')]
````