### PR TITLE
Upgrade dependency action references in GitHub Action pipelines

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,11 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '8.0' ]
+        php-version: [ '8.1' ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Paths filters
         uses: dorny/paths-filter@v2

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Bumps build action dependencies to latest versions, and sets build to validate in PHP 8.1 to ensure VIP environment compatibility.