### PR TITLE
916: Resolve PHP warnings and errors observed during 8.1 upgrade

### DIFF
--- a/single-profile.php
+++ b/single-profile.php
@@ -87,10 +87,12 @@ while ( have_posts() ) :
 								$img = get_template_directory_uri() . '/assets/src/svg/individual/wikimedia-blue.svg';
 							}
 							?>
-						<div class="bold profile-contacts"><a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>">
-							<img src="<?php echo esc_url( $img ); ?>" alt="">
-							<?php echo esc_html( $link['title'] ); ?>
-						</a></div>
+						<div class="bold profile-contacts">
+							<?php if ( isset( $link['link'] ) ) : ?><a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>"><?php endif; ?>
+								<img src="<?php echo esc_url( $img ); ?>" alt="">
+								<?php echo esc_html( $link['title'] ); ?>
+							<?php if ( isset( $link['link'] ) ) : ?></a><?php endif; ?>
+						</div>
 					</div>
 						<?php endforeach; ?>
 				<?php endif; ?>

--- a/single-profile.php
+++ b/single-profile.php
@@ -88,10 +88,14 @@ while ( have_posts() ) :
 							}
 							?>
 						<div class="bold profile-contacts">
-							<?php if ( isset( $link['link'] ) ) : ?><a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>"><?php endif; ?>
+							<?php if ( isset( $link['link'] ) ) : ?>
+							<a href="<?php echo strpos( $link['link'], 'mailto' ) !== false ? esc_url( 'mailto:' . antispambot( str_replace( 'mailto:', '', $link['link'] ) ) ) : esc_url( $link['link'] ); ?>">
+							<?php endif; ?>
 								<img src="<?php echo esc_url( $img ); ?>" alt="">
 								<?php echo esc_html( $link['title'] ); ?>
-							<?php if ( isset( $link['link'] ) ) : ?></a><?php endif; ?>
+							<?php if ( isset( $link['link'] ) ) : ?>
+							</a>
+							<?php endif; ?>
 						</div>
 					</div>
 						<?php endforeach; ?>

--- a/single-story.php
+++ b/single-story.php
@@ -31,8 +31,8 @@ while ( have_posts() ) :
 		'template-parts/header/story',
 		'single',
 		array(
-			'back_to_link'  => $parent_link,
-			'back_to_label' => $parent_name,
+			'back_to_link'  => $parent_link ?? '',
+			'back_to_label' => $parent_name ?? '',
 			'share_links'   => get_post_meta( get_the_ID(), 'contact_links', true ),
 		)
 	);

--- a/template-parts/header/profile-single.php
+++ b/template-parts/header/profile-single.php
@@ -16,7 +16,7 @@ $team_url     = get_term_link( $team_name[0]->term_id, $team_name[0]->taxonomy )
 $team_link    = is_string( $team_url ) ? '<a href="' . esc_url( $team_url ) . '">' . esc_html( $team_name[0]->name ) . '</a>' : '';
 $role_desc    = join( ', ', array_filter( [ $role_name, $team_link ] ) );
 
-if ( count( $team_name ) > 1 ) {
+if ( is_countable( $team_name ) && count( $team_name ) > 1 ) {
 	$role_array = [];
 
 	foreach ( $team_name as $team ) {


### PR DESCRIPTION
This PR addresses one fatal and three warnings observed in the application runtime logs while upgrading the Foundation site to PHP 8.1.

```
2023-11-08T18:11:16.880587639Z PHP message: Warning: Undefined array key "link" in /var/www/wp-content/themes/shiro/single-profile.php on line 90 [wikimediafoundation.org/profile/selena-deckelmann/] [wp-includes/template-loader.php:106 include('wp-content/themes/shiro/single-profile.php'), wp-blog-header.php:19 require_once('wp-includes/template-loader.php'), index.php:17 require('wp-blog-header.php')]

2023-11-08T18:11:44.203293989Z PHP message: Warning: Undefined variable $parent_link in /var/www/wp-content/themes/shiro/single-story.php on line 34 [wikimediafoundation.org/story/translations-and-copyright/] [wp-includes/template-loader.php:106 include('wp-content/themes/shiro/single-story.php'), wp-blog-header.php:19 require_once('wp-includes/template-loader.php'), index.php:17 require('wp-blog-header.php')]

2023-11-08T18:11:44.203441970Z PHP message: Warning: Undefined variable $parent_name in /var/www/wp-content/themes/shiro/single-story.php on line 35 [wikimediafoundation.org/story/translations-and-copyright/] [wp-includes/template-loader.php:106 include('wp-content/themes/shiro/single-story.php'), wp-blog-header.php:19 require_once('wp-includes/template-loader.php'), index.php:17 require('wp-blog-header.php')]

2023-11-08T19:04:03.386849536Z PHP message: PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given in /var/www/wp-content/themes/shiro/template-parts/header/profile-single.php:19
2023-11-08T19:04:03.386855828Z Stack trace:
2023-11-08T19:04:03.386859435Z #0 /var/www/wp-includes/template.php(792): require()
2023-11-08T19:04:03.386863162Z #1 /var/www/wp-includes/template.php(725): load_template('/var/www/wp-con...', false, Array)
...
```
See humanmade/wikimedia#916 for full log output.