### PR TITLE
916: Fix subsequent PHP fatal when trying to cast WP_Error to string

### DIFF
--- a/single-profile.php
+++ b/single-profile.php
@@ -20,8 +20,8 @@ while ( have_posts() ) :
 	$roles           = get_the_terms( get_the_ID(), 'role' );
 	$default_heading = get_theme_mod( 'wmf_related_profiles_heading', __( 'Other members of ', 'shiro-admin' ) );
 	$team_name       = '';
-	$parent_name     = $roles[0]->name;
-	$parent_link     = get_term_link( $roles[0] );
+	$parent_name    = $roles[0]->name;
+	$parent_link    = get_term_link( $roles[0] );
 	$connected_user = get_post_meta( get_the_ID(), 'connected_user', true );
 
 	if ( ! empty( $roles ) && ! is_wp_error( $roles ) ) {

--- a/template-parts/header/profile-single.php
+++ b/template-parts/header/profile-single.php
@@ -35,9 +35,13 @@ if ( is_countable( $team_name ) && count( $team_name ) > 1 ) {
 <div class="header-main header-role">
 	<div class="header-content">
 		<h2 class="h4 eyebrow">
+			<?php if ( ! empty( $back_to_link ) && is_string( $back_to_link ) ) : ?>
 			<a class="back-arrow-link" href="<?php echo esc_url( $back_to_link ); ?>">
+			<?php endif; ?>
 				<?php echo esc_html( $staff_name ); ?>
+			<?php if ( ! empty( $back_to_link ) && is_string( $back_to_link ) ) : ?>
 			</a>
+			<?php endif; ?>
 		</h2>
 
 		<h1><?php the_title(); ?></h1>


### PR DESCRIPTION
Resolves error when passing WP_Error to `esc_url`, by asserting value is a string before rendering link.

```
Uncaught TypeError: ltrim(): Argument #1 ($string) must be of type string, WP_Error given
```

See humanmade/wikimedia#916