### PR TITLE
916: Fix PHP fatal: Guard against string values of rand_translation

### DIFF
--- a/template-parts/page/page-stories.php
+++ b/template-parts/page/page-stories.php
@@ -15,7 +15,9 @@ $rand_translation = wmf_get_random_translation(
 	)
 );
 
-$template_args['rand_translation_title'] = $rand_translation['pre_heading'] ?? '';
+$template_args['rand_translation_title'] = is_array( $rand_translation )
+	? $rand_translation['pre_heading'] ?? ''
+	: '';
 
 if ( ! empty( $template_args ) ) {
 	get_template_part( 'template-parts/modules/stories/list', null, $template_args );


### PR DESCRIPTION
Resolves PHP fatal,
```
PHP message: Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /var/www/wp-content/themes/shiro/template-parts/page/page-stories.php:18
```

See humanmade/wikimedia#916