### PR TITLE
916: Fix PHP fatal: Consistently guard against empty-string template-args

### DIFF
--- a/template-parts/modules/list/list.php
+++ b/template-parts/modules/list/list.php
@@ -41,7 +41,7 @@ foreach ( $template_args as $i => $list_section ) {
 	</div>
 	<?php endif; ?>
 
-	
+
 	<?php if ( isset( $list_section['links'] ) ) : ?>
 		<ul class="link-list">
 		<?php

--- a/template-parts/page/page-profiles.php
+++ b/template-parts/page/page-profiles.php
@@ -9,6 +9,10 @@
 
 $template_args = get_post_meta( get_the_ID(), 'profiles', true );
 
+if ( ! is_array( $template_args ) ) {
+	$template_args = [];
+}
+
 $rand_translation = wmf_get_random_translation(
 	'profiles', array(
 		'source' => 'meta',

--- a/template-parts/page/page-related.php
+++ b/template-parts/page/page-related.php
@@ -5,7 +5,12 @@
  * @package shiro
  */
 
-$template_args               = get_post_meta( get_the_ID(), 'related_pages', true );
+$template_args = get_post_meta( get_the_ID(), 'related_pages', true );
+
+if ( ! is_array( $template_args ) ) {
+	$template_args = [];
+}
+
 $template_args['preheading'] = get_theme_mod( 'wmf_related_pages_pre_heading', __( 'Related', 'shiro-admin' ) );
 
 get_template_part( 'template-parts/modules/related/pages', null, $template_args );


### PR DESCRIPTION
For humanmade/wikimedia#916

In my local, this resolves all remaining issues with the Stories and Annual Reports pages, and introduces a similar guard in other templates that have not been observed to be a problem.

We could consider refactoring this to a `get_template_args_from_meta` that applies the empty-check internally, but for now, this patch should resolve the production issues.