### PR TITLE
Fix News page margin on narrow viewports

### DIFF
--- a/home.php
+++ b/home.php
@@ -27,41 +27,43 @@ get_template_part( 'template-parts/header/page-noimage', null, $template_args );
 
 <?php get_template_part( 'template-parts/post-list-filters' ); ?>
 
-<div class="blog-list">
+<div class="mw-980">
+	<div class="blog-list">
 
-	<?php
-	$post = get_post( $featured_post_id );
-	if ( ! empty( $post ) ) {
-		$featured_post_id = (int) $post->ID;
-		echo wp_kses_post( WMF\Editor\Blocks\BlogPost\render_block(
-			[
-				'post_id' => $featured_post_id,
-				'is_featured' => true,
-			]
-		) );
-	}
-	?>
-
-	<?php get_template_part( 'template-parts/category-list' ); ?>
-
-	<?php
-	if ( have_posts() ) :
-		while ( have_posts() ) :
-			the_post();
-
-			if ( get_the_ID() === intval( $featured_post_id ) ) {
-				continue;
-			}
-
+		<?php
+		$post = get_post( $featured_post_id );
+		if ( ! empty( $post ) ) {
+			$featured_post_id = (int) $post->ID;
 			echo wp_kses_post( WMF\Editor\Blocks\BlogPost\render_block(
-				[ 'post_id' => $post->ID ]
+				[
+					'post_id' => $featured_post_id,
+					'is_featured' => true,
+				]
 			) );
-		endwhile;
-	else :
-		get_template_part( 'template-parts/content', 'none' );
-	endif;
-	?>
+		}
+		?>
 
+		<?php get_template_part( 'template-parts/category-list' ); ?>
+
+		<?php
+		if ( have_posts() ) :
+			while ( have_posts() ) :
+				the_post();
+
+				if ( get_the_ID() === intval( $featured_post_id ) ) {
+					continue;
+				}
+
+				echo wp_kses_post( WMF\Editor\Blocks\BlogPost\render_block(
+					[ 'post_id' => $post->ID ]
+				) );
+			endwhile;
+		else :
+			get_template_part( 'template-parts/content', 'none' );
+		endif;
+		?>
+
+	</div>
 </div>
 
 <?php

--- a/template-parts/post-list-filters.php
+++ b/template-parts/post-list-filters.php
@@ -151,4 +151,4 @@ if ( isset( $_GET['post_list_filters_nonce'] ) && wp_verify_nonce( sanitize_text
 
 	</form>
 
-</div>
+</section>


### PR DESCRIPTION
Fixes humanmade/wikimedia#833: News section did not have margin on small viewports

- Incorrect closing tag in filter interface, which caused browser to prematurely terminate the <main> tag
- Adds a wrapper class to the blog-list component on the homepage template to ensure it gets the consistent mobile margin