### PR TITLE
920: Guard against direct file access

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 $template_args = array(

--- a/comments.php
+++ b/comments.php
@@ -10,6 +10,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 /*
  * If the current post is protected by a password and
  * the visitor has not yet entered the password we will

--- a/footer.php
+++ b/footer.php
@@ -11,6 +11,10 @@
 
 use WMF\Images\Credits;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 // Automatically add credits to all content that is not an archive or search.
 if ( ! is_archive() && ! is_home() ) {
 	get_template_part( 'template-parts/modules/images/credits', null, array( 'image_ids' => Credits::get_instance()->get_ids() ) );

--- a/front-page.php
+++ b/front-page.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 /**
  * This loads the blocks template if the front page is using blocks.
  * This is necessary as a conditional so that the "old" home page can exist

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  *

--- a/header.php
+++ b/header.php
@@ -11,6 +11,10 @@
 
 use WMF\Images\Credits;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 $wmf_translation_selected = get_theme_mod( 'wmf_selected_translation_copy', __( 'Languages', 'shiro-admin' ) );
 $wmf_translations         = array_filter( wmf_get_translations(), function ( $translation ) {
 	return $translation['uri'] !== '';

--- a/home.php
+++ b/home.php
@@ -12,6 +12,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 $post_id          = get_option( 'page_for_posts' );

--- a/index.php
+++ b/index.php
@@ -12,6 +12,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header(); ?>
 
 <?php

--- a/page-block-editor.php
+++ b/page-block-editor.php
@@ -10,6 +10,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 while ( have_posts() ) {

--- a/page-data.php
+++ b/page-data.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) {
 	the_post();
@@ -31,7 +35,7 @@ while ( have_posts() ) {
 				<?php get_template_part( 'template-parts/page/page', 'intro' ); ?>
 			</div>
 		</div>
-		<?php 
+		<?php
 	}
 	?>
 

--- a/page-freeform.php
+++ b/page-freeform.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) {
 	the_post();

--- a/page-landing.php
+++ b/page-landing.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) {
 	the_post();

--- a/page-list.php
+++ b/page-list.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) :
 	the_post();

--- a/page-report-landing.php
+++ b/page-report-landing.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) {
 	the_post();

--- a/page-report-section.php
+++ b/page-report-section.php
@@ -10,6 +10,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) :
 	the_post();

--- a/page-report.php
+++ b/page-report.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) :
 	the_post();

--- a/page.php
+++ b/page.php
@@ -12,6 +12,10 @@
  * @package shiro
  */
 
+ if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 // When everything is build with the block editor, this entire file can be
 // replaced by page-block-editor.php
 if ( has_blocks() ) {

--- a/search.php
+++ b/search.php
@@ -6,6 +6,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 $wmf_results_copy = get_theme_mod( 'wmf_search_results_copy', /* translators: 1. search query */ __( 'Search results for %s', 'shiro-admin' ) );

--- a/sidebar.php
+++ b/sidebar.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 $facts     = get_post_meta( get_the_ID(), 'sidebar_facts', true );
 $downloads = get_post_meta( get_the_ID(), 'sidebar_downloads', true );
 

--- a/single-story.php
+++ b/single-story.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 while ( have_posts() ) :

--- a/single.php
+++ b/single.php
@@ -7,6 +7,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 while ( have_posts() ) {
 	the_post();
@@ -48,7 +52,7 @@ while ( have_posts() ) {
 				'<span>%s</span><span class="separator">&bull;</span><time datetime="%s">%s</time>',
 				wmf_byline(),
 				get_the_date( 'c' ),
-				get_the_date() 
+				get_the_date()
 			),
 		)
 	);
@@ -81,8 +85,8 @@ while ( have_posts() ) {
 					array(
 						'enableTwitter'  => true,
 						'enableFacebook' => true,
-					) 
-				) 
+					)
+				)
 			);
 		}
 

--- a/taxonomy-role.php
+++ b/taxonomy-role.php
@@ -12,6 +12,10 @@
  * @package shiro
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // File should never be accessed directly.
+}
+
 get_header();
 
 $h4_title = '';


### PR DESCRIPTION
VIP runtime logs reveal that some requests are made directly to theme files, which is possibly benign but also possibly as a penetration testing tactic. The file will not load if WordPress is not running, because `get_header()` will not be defined, but this guard code ensures that the page exits immediately if any top-level theme file is accessed.

Fixes humanmade/wikimedia#920