### PR TITLE
#925: Update to Content Security Policy (CSP) to fix issues on Jetpack, Matomo and WordPress Admin

### DIFF
--- a/inc/security.php
+++ b/inc/security.php
@@ -59,7 +59,7 @@ function set_content_security_policy() {
 		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080",
 		"frame-src 'self' https://www.youtube.com https://player.vimeo.com",
 		"style-src 'self' 'unsafe-inline'",
-		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org",
+		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
 		"font-src 'self' data:",
 		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org",
 	);

--- a/inc/security.php
+++ b/inc/security.php
@@ -61,7 +61,7 @@ function set_content_security_policy() {
 		"style-src 'self' 'unsafe-inline' https://s0.wp.com",
 		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
 		"font-src 'self' data: https://s0.wp.com",
-		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org",
+		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org wss://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data",
 	);
 
 	header( 'Content-Security-Policy: ' . implode( '; ', $csp_allowed ) );

--- a/inc/security.php
+++ b/inc/security.php
@@ -58,10 +58,10 @@ function set_content_security_policy() {
 		"default-src 'self'",
 		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080 https://s0.wp.com",
 		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://widgets.wp.com",
-		"style-src 'self' 'unsafe-inline' https://s0.wp.com",
-		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
+		"style-src 'self' 'unsafe-inline' https://s0.wp.com https://piwik.wikimedia.org",
+		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com",
 		"font-src 'self' data: https://s0.wp.com",
-		"connect-src 'self' https://*.wikipedia.org wss://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data",
+		"connect-src 'self' https://*.wikipedia.org wss://public-api.wordpress.com",
 	);
 
 	header( 'Content-Security-Policy: ' . implode( '; ', $csp_allowed ) );

--- a/inc/security.php
+++ b/inc/security.php
@@ -56,9 +56,9 @@ function set_content_security_policy() {
 
 	$csp_allowed = array(
 		"default-src 'self'",
-		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080",
-		"frame-src 'self' https://www.youtube.com https://player.vimeo.com",
-		"style-src 'self' 'unsafe-inline'",
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080 https://s0.wp.com",
+		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://widgets.wp.com",
+		"style-src 'self' 'unsafe-inline' https://s0.wp.com",
 		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
 		"font-src 'self' data:",
 		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org",

--- a/inc/security.php
+++ b/inc/security.php
@@ -56,12 +56,12 @@ function set_content_security_policy() {
 
 	$csp_allowed = array(
 		"default-src 'self'",
-		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://piwik.wikimedia.org https://stats.wp.com https://pixel.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080 https://s0.wp.com",
-		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://widgets.wp.com",
-		"style-src 'self' 'unsafe-inline' https://s0.wp.com https://piwik.wikimedia.org",
-		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com",
-		"font-src 'self' data: https://s0.wp.com",
-		"connect-src 'self' https://*.wikipedia.org wss://public-api.wordpress.com",
+		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.wikimedia.org https://*.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080",
+		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://*.wp.com",
+		"style-src 'self' 'unsafe-inline' https://*.wikimedia.org https://*.wp.com",
+		"img-src 'self' data: https://*.wikimedia.org https://*.wp.com",
+		"font-src 'self' data: https://*.wp.com",
+		"connect-src 'self' https://*.wikipedia.org wss://*.wordpress.com",
 	);
 
 	header( 'Content-Security-Policy: ' . implode( '; ', $csp_allowed ) );

--- a/inc/security.php
+++ b/inc/security.php
@@ -60,7 +60,7 @@ function set_content_security_policy() {
 		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://widgets.wp.com",
 		"style-src 'self' 'unsafe-inline' https://s0.wp.com",
 		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
-		"font-src 'self' data:",
+		"font-src 'self' data: https://s0.wp.com",
 		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org",
 	);
 

--- a/inc/security.php
+++ b/inc/security.php
@@ -61,7 +61,7 @@ function set_content_security_policy() {
 		"style-src 'self' 'unsafe-inline' https://s0.wp.com",
 		"img-src 'self' data: https://piwik.wikimedia.org https://wikipedia.org https://upload.wikimedia.org https://pixel.wp.com/g.gif",
 		"font-src 'self' data: https://s0.wp.com",
-		"connect-src 'self' wss://public-api.wordpress.com https://*.wikipedia.org wss://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data",
+		"connect-src 'self' https://*.wikipedia.org wss://public-api.wordpress.com/pinghub/wpcom/me/newest-note-data",
 	);
 
 	header( 'Content-Security-Policy: ' . implode( '; ', $csp_allowed ) );


### PR DESCRIPTION
This PR focuses on updating the Content Security Policy (CSP) to allow exceptions crucial for Jetpack, Matomo analytics and WordPress Admin Backend. These exceptions are necessary to ensure full functionality of these tools while maintaining the security standards of our site.

### Overview
Modifications to the CSP settings in `inc/security.php` are implemented to support scripts, frames, styles, images, fonts, and connection endpoints from trusted external sources related to Jetpack, Matomo, and essential admin features.

### Changes
The `set_content_security_policy()` function has been updated with the following exceptions:
- Script Source: https://s0.wp.com added for Jetpack scripts
- Frame Source: https://widgets.wp.com included for Jetpack widgets
- Style Source: Expanded with https://s0.wp.com and Matomo (https://piwik.wikimedia.org)
- Image Source: https://pixel.wp.com enabled for Jetpack tracking pixels
- Font Source: Fonts from https://s0.wp.com allowed for consistency in admin interfaces.
- Connect Source: WordPress funcionality

### Testing
- Check that CSP headers are correctly implemented looking on HTTP Headers
- Confirm operational integrity of Jetpack and Matomo services.
- Ensure admin functionalities are unaffected and secure.

### Additional Notes
- Vigilant monitoring for CSP violations errors on post-implementation is essential
- Regular reviews and updates to the CSP are recommended for optimal balance between functionality and security