### PR TITLE
[WIP] Fix PHP warning fixes

### DIFF
--- a/sidebar-list.php
+++ b/sidebar-list.php
@@ -58,7 +58,7 @@ if ( empty( $template_args ) ) {
 <?php endif; ?>
 	<?php
 	foreach ( $template_args as $i => $list_section ) :
-		$item_text = $list_section['title'] ?? $list_section['name'];
+		$item_text = $list_section['title'] ?? $list_section['name'] ?? '';
 		$item_link = ( $list_section['slug'] ?? false ) ? '#' . $list_section['slug'] : '#section-' . ( $i + 1 );
 		if ( empty( $item_text ) ) {
 			continue;

--- a/single-profile.php
+++ b/single-profile.php
@@ -73,6 +73,10 @@ while ( have_posts() ) :
 							?>
 					<div class="link-list mar-right">
 							<?php
+							// Avoid undefined array index warnings.
+							$link['link']  = $link['link'] ?? '';
+							$link['title'] = $link['title'] ?? '';
+
 							$img = '';
 							if ( is_int( strpos( $link['link'], 'meta.wikimedia.org' ) ) ) {
 								$img = get_template_directory_uri() . '/assets/src/svg/globe.svg';


### PR DESCRIPTION
This PR is part of our ongoing effort to maintain clean and efficient logs by addressing and resolving specific PHP warning messages, as keeping the log free of not so important warnings is crucial for efficient debugging and monitoring, ensuring that we can quickly identify and address more significant issues when they arise.

### Changes

1. **sidebar-list.php**:
   - Refined the definition of `$item_text` to default to an empty string if neither 'title' nor 'name' keys are set in `$list_section`, addressing the warning: `PHP Warning: Undefined array key "name" in sidebar-list.php on line 61`.

2. **single-profile.php**:
   - Add lines to set default values for `$link['link']` and `$link['title']` if not present in the `$share_links` array, addressing multiple warnings of the form: `PHP Warning: Undefined array key "link" in single-profile.php on line [77, 80, 83, 86]`.

