### PR TITLE
Enable media fallback for local dev environments

### DIFF
--- a/inc/security.php
+++ b/inc/security.php
@@ -59,7 +59,7 @@ function set_content_security_policy() {
 		"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.wikimedia.org https://*.wp.com https://www.youtube.com https://player.vimeo.com http://localhost https://localhost http://localhost:8080",
 		"frame-src 'self' https://www.youtube.com https://player.vimeo.com https://*.wp.com",
 		"style-src 'self' 'unsafe-inline' https://*.wikimedia.org https://*.wp.com",
-		"img-src 'self' data: https://*.wikimedia.org https://*.wp.com",
+		"img-src 'self' data: https://*.wikimedia.org https://*.wp.com https://wikimediafoundation.org",
 		"font-src 'self' data: https://*.wp.com",
 		"connect-src 'self' https://*.wikipedia.org wss://*.wordpress.com",
 	);


### PR DESCRIPTION
If you [enable a media fallback URL](https://docs.wpvip.com/how-tos/dev-env-add-media/#h-proxy-media-files) to proxy media file requests to the production site (which is helpful because it lets you run your local without downloading the `uploads/` directory!), currently those images do not load because of our CSP. "self" represents the foundation site in production, so it should always be safe to load images from it in other environments, because those environments' data comes one-way from that production foundation site.

With this change, if you create a local environment with a media redirect fallback domain, like this,

```
vip dev-env create --slug=wikimedia --media-redirect-domain=wikimediafoundation.org
```

then all images will load as soon as you run

```
vip dev-env sync sql @wikimediafoundation.production --slug=wikimedia
```

and you will not need to do any manual download of the `uploads/` dir.