### PR TITLE
#924: Fix embed YouTube video so the video and thumbnail remains responsive on multiple viewport sizes

### DIFF
--- a/assets/src/sass/components/_embed-youtube.scss
+++ b/assets/src/sass/components/_embed-youtube.scss
@@ -1,0 +1,6 @@
+.youtube-player {
+	aspect-ratio: 16/9;
+	height: auto;
+	min-width: 321px; /* YouTube shows a low quality thumb image if the width is <= 320px */
+	width: 100%;
+}

--- a/assets/src/sass/style.scss
+++ b/assets/src/sass/style.scss
@@ -47,5 +47,6 @@
 @import "components/primary-nav-toggle";
 @import "components/site-footer";
 @import "components/post-list-filters";
+@import "components/embed-youtube";
 
 @import "blocks/index";


### PR DESCRIPTION
## Description
This PR addresses the issue where the YouTube video embed block was not dynamically adjusting to the format of the embedded video, causing the video thumbnails to be cropped. The modification ensures that the video embed block and the player adapt seamlessly to the screen size and the video format, providing an optimal viewing experience without cropping or visual discrepancies. 

### How it was looking

#### Desktop
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/0b5df2a5-761d-4584-99cf-4eb76811e8ae)

#### Mobile (iPhone 12 Pro)
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/c1896184-060b-452f-905e-c42005573da2)

### How it's looking now

#### Desktop
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/2e69a51e-8234-440b-a6fa-07b0b89a56fc)

#### Mobile (iPhone 12 Pro)
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/fc4d0f69-7b07-454b-a553-d9bb436ae5e7)

### Minimum video width
I set the minimum width of 321 px to the videos, to ensures that YouTube does not default to a low-quality thumbnail.

#### Example of a low-quality thumbnail when video width = 320 px
![image](https://github.com/wikimedia/shiro-wordpress-theme/assets/90911997/8e96e72b-e231-4135-8be5-90a318c32dc9)

## Consistency test across browsers
Feature was tested on these platforms / clients:
- [x] GNU/Linux / Google Chrome v119
- [x] iPhone 12 / Google Chrome v92
- [x] iPhone 13 / Safari
- [x] Android Samsung Galaxy S20 / Chrome
- [x] macOS Sonoma / Firefox v120
- [x] macOS Sonoma / Safari v17
- [x] macOS Monterrey / Chrome v119
- [x] Windows / Edge v119
- [x] Windows / Chrome v119

## Testing instructions
- Navigate to the ["Knowledge is Human" page (on develop)](https://wikimediafoundation-org-develop.go-vip.co/our-work/knowledge-is-human/)
- Scroll down to the "Wikimedia: Supporting free knowledge" section.
- Observe the video embed block under this section: The video thumbnails are now be fully visible without cropping.
- On clicking the video, both the player and block element should adjust to the screen size.

## Acceptance Criteria
- [x] Video embed block dynamically adjusts to the format of the embedded video.
- [x] Entire video thumbnail is visible without automatic cropping.
- [x] Player and block element adapt to the screen size when users click to watch the video.