### PR TITLE
Wikimedia-900: Delegate header generation to security plugin when present

### DIFF
--- a/inc/security.php
+++ b/inc/security.php
@@ -15,7 +15,7 @@ namespace WMF\Security;
  * Once security plugin is stable, this logic can be removed.
  */
 function init() {
-	if ( ! function_exists( 'Wikimedia\\Security\\CSP\\bootstrap' ) ) {
+	if ( ! function_exists( 'WMF\\Security\\CSP\\bootstrap' ) ) {
 		add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security.
 	}
 	if ( ! function_exists( 'WMF\\Security\\HTTP_Headers\\bootstrap' ) ) {

--- a/inc/security.php
+++ b/inc/security.php
@@ -9,13 +9,21 @@ namespace WMF\Security;
 
 /**
  * Booting up the security functionalities.
+ *
+ * Delegate these responsibilities to the security plugin, if active.
+ *
+ * Once security plugin is stable, this logic can be removed.
  */
 function init() {
-	add_action( 'send_headers', __NAMESPACE__ . '\\enable_strict_transport_security' ); // Making sure of HTTPS.
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security.
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_x_content_type_options' ); // Option of X Content Type.
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_referrer_policy' ); // Policy for referrer.
-	add_action( 'send_headers', __NAMESPACE__ . '\\set_permissions_policy' ); // Policy for permissions.
+	if ( ! function_exists( 'Wikimedia\\Security\\CSP\\bootstrap' ) ) {
+		add_action( 'send_headers', __NAMESPACE__ . '\\set_content_security_policy' ); // Policy for content security.
+	}
+	if ( ! function_exists( 'WMF\\Security\\HTTP_Headers\\bootstrap' ) ) {
+		add_action( 'send_headers', __NAMESPACE__ . '\\enable_strict_transport_security' ); // Making sure of HTTPS.
+		add_action( 'send_headers', __NAMESPACE__ . '\\set_x_content_type_options' ); // Option of X Content Type.
+		add_action( 'send_headers', __NAMESPACE__ . '\\set_referrer_policy' ); // Policy for referrer.
+		add_action( 'send_headers', __NAMESPACE__ . '\\set_permissions_policy' ); // Policy for permissions.
+	}
 }
 
 /**


### PR DESCRIPTION
This needs testing, but this theme must delegate the CSP header generation to the new security plugin when that plugin is present and active.