### PR TITLE
#923: Ensure complete profile listing on role pages by correcting posts array combination logic

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -157,8 +157,11 @@ function wmf_get_role_posts( $term_id ) {
 		}
 	}
 
+	$profile_list = array_merge( $featured_list, $posts->posts );
+	$profile_list = array_unique( $profile_list );
+
 	return array(
-		'posts' => $featured_list + $posts->posts,
+		'posts' => $profile_list,
 		'name'  => $term_query->name,
 		'slug'  => $term_query->slug,
 	);
@@ -184,7 +187,7 @@ function wmf_get_posts_by_child_roles( $term_id ) {
 
 	$cached_posts = wp_cache_get( 'wmf_terms_list_' . $term_id );
 
-	if ( ! empty( $cached_posts ) ) {
+	if ( ! empty( $cached_posts ) && false ) {
 		return $cached_posts;
 	}
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -187,7 +187,7 @@ function wmf_get_posts_by_child_roles( $term_id ) {
 
 	$cached_posts = wp_cache_get( 'wmf_terms_list_' . $term_id );
 
-	if ( ! empty( $cached_posts ) && false ) {
+	if ( ! empty( $cached_posts ) ) {
 		return $cached_posts;
 	}
 


### PR DESCRIPTION
This PR addresses an issue affecting all role/profile list pages. The issue was initially detected by WMF ticket [#923: Missing trustee profiles on Board of trustees landing page](https://github.com/humanmade/Wikimedia/issues/923) as some profiles were missing on the "Board of Trustees" role list.

## Issue description
The existing implementation used the array union operator (+) for joining featured profiles and profiles related to the specific role, which led to the omission of profiles with overlapping keys in the arrays. This fix ensures complete and accurate profile listings across all such pages.

## Changes
- Replaced the array union operation `$featured_list + $posts->posts` with a combination of `array_merge` and `array_unique`. This change is implemented in `wmf_get_role_posts function` within `template-functions.php` file - `array_merge` is used to concatenate `$featured_list` and `$posts->posts` arrays. It ensures all profiles are included, even if their array keys overlap.
- `array_unique` is then applied to the merged array to remove any duplicate profiles, maintaining data integrity and preventing redundancy in the listing.

> [!IMPORTANT]  
> This issue was impacting all role / profiles listing pages, not only "Board of Trustees" as reported on WMF ticket #923.

## Testing instructions
- Check if all profiles are being listed on roles pages.