### PR TITLE
Hotfix: PHP Fatal on inc/template-functions.php line 99

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -104,6 +104,8 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 	foreach ( $terms as $term_id => $parent ) {
 		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
+		} else {
+			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) );
 		}
 	}
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -93,7 +93,13 @@ function wmf_get_header_cta_button_class() {
 function wmf_get_role_hierarchy( int $parent_id ) {
 	$children   = array();
 	$term_array = array();
-	$terms      = get_terms( 'role' );
+	$terms      = get_terms(
+		'role', array(
+			'orderby' => 'name',
+			'fields'  => 'id=>parent',
+			'get'     => 'all',
+		)
+	);
 
 	foreach ( $terms as $term_id => $parent ) {
 		// Ensure that $parent is an integer and greater than 0.

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -86,22 +86,18 @@ function wmf_get_header_cta_button_class() {
 /**
  * Get all the child terms for a parent organized by hierarchy
  *
- * @param int $parent_id ID to query against.
- * @return array List of organized IDs.
+ * @param int $parent_id The ID of the parent term to query against.
+ * @return array|false An associative array of child terms organized by their IDs,
+ *                     or false if no children are found for the given parent ID.
  */
-function wmf_get_role_hierarchy( $parent_id ) {
+function wmf_get_role_hierarchy( int $parent_id ) {
 	$children   = array();
 	$term_array = array();
-	$terms      = get_terms(
-		'role', array(
-			'orderby' => 'name',
-			'fields'  => 'id=>parent',
-			'get'     => 'all',
-		)
-	);
+	$terms      = get_terms( 'role' );
 
 	foreach ( $terms as $term_id => $parent ) {
-		if ( 0 < $parent ) {
+		// Ensure that $parent is an integer and greater than 0.
+		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
 		}
 	}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -105,7 +105,8 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
 		} else {
-			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log, WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Intentionally using error_log with var_export for detailed troubleshooting.
+			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) );
 		}
 	}
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -102,7 +102,6 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 	);
 
 	foreach ( $terms as $term_id => $parent ) {
-		// Ensure that $parent is an integer and greater than 0.
 		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
 		}
@@ -175,7 +174,7 @@ function wmf_get_role_posts( $term_id ) {
  * @param int $term_id  ID of parent term.
  * @return array list of organized posts or empty array.
  */
-function wmf_get_posts_by_child_roles( $term_id ) {
+function wmf_get_posts_by_child_roles( int $term_id ) {
 	$post_list = array();
 
 	$term = get_term( $term_id );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -105,7 +105,7 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
 		} else {
-			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) );
+			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
 


### PR DESCRIPTION
This PR intends to add a hotfix which was breaking role pages on `develop`.

Example of role page:
https://wikimediafoundation-org-develop.go-vip.co/role/board/

Error being thrown:
```
PHP message: PHP Fatal error: Uncaught TypeError: Illegal offset type in /var/www/wp-content/themes/shiro/inc/template-functions.php:99
```

I already deployed this hotfix to Shiro's `develop`, and updated WMF `develop`, fixing the issue, assuring that the fix was effective.