### PR TITLE
Update dev dependencies and guard against missing PostControl

### DIFF
--- a/assets/src/editor/blocks/profile-list/index.js
+++ b/assets/src/editor/blocks/profile-list/index.js
@@ -14,9 +14,8 @@ import ServerSideRender from '@wordpress/server-side-render';
 /**
  * Internal dependencies
  */
+import PostControl from '../../components/post-control';
 import './style.scss';
-
-const { PostControl } = hm.controls;
 
 export const name = 'shiro/profile-list';
 

--- a/assets/src/editor/blocks/profile/index.js
+++ b/assets/src/editor/blocks/profile/index.js
@@ -14,9 +14,8 @@ import ServerSideRender from '@wordpress/server-side-render';
 /**
  * Internal dependencies
  */
+import PostControl from '../../components/post-control';
 import './style.scss';
-
-const { PostControl } = hm.controls;
 
 export const name = 'shiro/profile';
 

--- a/assets/src/editor/components/post-control.js
+++ b/assets/src/editor/components/post-control.js
@@ -1,0 +1,15 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Fallback component to render if the PostControl is not found.
+ *
+ * This prevents other bundled blocks from failing to initialize if the HM
+ * Gutenberg Tools plugin is not active.
+ */
+const FallbackComponent = () => (
+	<p>{ __( 'HM Gutenberg Tools not found' ) }</p>
+);
+
+const PostControl = hm?.controls?.PostControl || FallbackComponent;
+
+export default PostControl;

--- a/assets/src/editor/components/post-control.js
+++ b/assets/src/editor/components/post-control.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Gutenberg Tools plugin is not active.
  */
 const FallbackComponent = () => (
-	<p>{ __( 'HM Gutenberg Tools not found' ) }</p>
+	<p>{ __( 'HM Gutenberg Tools not found', 'shiro' ) }</p>
 );
 
 const PostControl = hm?.controls?.PostControl || FallbackComponent;

--- a/assets/src/editor/components/post-control.js
+++ b/assets/src/editor/components/post-control.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Gutenberg Tools plugin is not active.
  */
 const FallbackComponent = () => (
-	<p>{ __( 'HM Gutenberg Tools not found', 'shiro' ) }</p>
+	<p>{ __( 'HM Gutenberg Tools Plugin not found', 'shiro' ) }</p>
 );
 
 const PostControl = hm?.controls?.PostControl || FallbackComponent;

--- a/composer.lock
+++ b/composer.lock
@@ -350,16 +350,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -369,7 +369,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -388,22 +388,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "staabm/annotate-pull-request-from-checkstyle",


### PR DESCRIPTION
Follow-on from #130 (and subsequent commits to `main`) to get us the latest and greatest, and also test that actions are running properly on PRs.

Also includes a guard associated with humanmade/wikimedia#927 