### PR TITLE
Remove error log debug info

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -104,9 +104,6 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 	foreach ( $terms as $term_id => $parent ) {
 		if ( is_int( $parent ) && $parent > 0 ) {
 			$children[ $parent ][] = $term_id;
-		} else {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log, WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Intentionally using error_log with var_export for detailed troubleshooting.
-			error_log( sprintf( 'Term ID %d has an invalid parent ID of [%s].', $term_id, var_export( $parent, true ) ) );
 		}
 	}
 


### PR DESCRIPTION
A PHP Fatal error was encountered on the Roles listing page. To immediately mitigate this, a provisional fix was introduced in PR [#129](https://github.com/wikimedia/shiro-wordpress-theme/pull/129).

It was needed to trace the root cause of this error, as it may reveal broader systemic issues within our codebase. 

After deploying the fix code, the error log provided us some important info, so logging the error is no longer necessary.

Details added to error log
```
Term ID 990: Invalid parent ID of [0].
Term ID 16: Invalid parent ID of [0].
Term ID 9: Invalid parent ID of [0].
Term ID 10: Invalid parent ID of [0].
```

So, the guard of checking `if ( is_int( $parent ) && $parent > 0 ) {` is enough for the case.