### PR TITLE
954: Avoid meta sort in profile query to ensure all records are returned

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -130,10 +130,6 @@ function wmf_get_role_posts( $term_id ) {
 		array(
 			'post_type'      => 'profile',
 			'fields'         => 'ids',
-			'orderby'        => 'title',
-			'meta_key'       => 'last_name',
-			'orderby'        => 'meta_value',
-			'order'          => 'ASC',
 			'posts_per_page' => 100,
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'tax_query'      => array(
@@ -160,6 +156,9 @@ function wmf_get_role_posts( $term_id ) {
 
 	$profile_list = array_merge( $featured_list, $posts->posts );
 	$profile_list = array_unique( $profile_list );
+
+	// Sort by last_name. Unusual profile ordering may occur if this field is not set.
+	usort( $profile_list, fn( $profile_id ) => get_post_meta( $profile_id, 'last_name', true ) );
 
 	return array(
 		'posts' => $profile_list,


### PR DESCRIPTION
We had an unusual situation on WIKI-954 where the profile of Stephen LaPorte, the Foundation's current General Counsel, was not showing up in the list of profiles with the 'executive' role. Stephen's profile had the correct 'executive' role term associated, and was properly published, but his profile's ID was not returned in the results of the WP_Query from the `wmf_get_role_posts()` function.

I identified that ordering by meta_value causes WP_Query to generate a SQL query which _excludes_ any records which do not have the specified meta key set. This is actually tracked as a long-standing WP Core bug:

https://core.trac.wordpress.org/ticket/19653

The quickest solution to the problem is to remove the `orderby` entirely, and sort the array in-memory within PHP before returning the query results for caching.

I also took it as an excuse to introduce this theme's first PHP Arrow Function :)