### PR TITLE
Remove the Homepage Hero srcset Attribute

### DIFF
--- a/assets/src/editor/blocks/banner/index.js
+++ b/assets/src/editor/blocks/banner/index.js
@@ -221,6 +221,7 @@ export const settings = {
 					<ImagePicker.Content
 						alt={ imageAlt }
 						className="banner__image"
+						id={ imageID }
 						imageSize={ 'medium_large' }
 						src={ imageSrc }
 					/>

--- a/assets/src/editor/blocks/banner/index.js
+++ b/assets/src/editor/blocks/banner/index.js
@@ -221,7 +221,6 @@ export const settings = {
 					<ImagePicker.Content
 						alt={ imageAlt }
 						className="banner__image"
-						id={ imageID }
 						imageSize={ 'medium_large' }
 						src={ imageSrc }
 					/>

--- a/assets/src/editor/blocks/home-page-hero/edit.js
+++ b/assets/src/editor/blocks/home-page-hero/edit.js
@@ -70,7 +70,6 @@ const HomePageHeroBlock = ( { attributes, setAttributes, isSelected, setHeadingC
 				) }>
 					<ImagePicker
 						className="hero-home__image"
-						id={ imageId }
 						labels={ {
 							instructions: __( '⚠️ Scrolling images are expected to be 4237px high and 454px wide (or multiples of those values). Using a different resolution will result in strange behavior.', 'shiro-admin' ),
 						} }

--- a/assets/src/editor/blocks/home-page-hero/index.js
+++ b/assets/src/editor/blocks/home-page-hero/index.js
@@ -105,7 +105,6 @@ export const settings = {
 	 */
 	save: function Save( { attributes } ) {
 		const {
-			imageId,
 			imageUrl,
 			imageAlt,
 			enableAnimation,
@@ -134,7 +133,6 @@ export const settings = {
 						<ImagePicker.Content
 							alt={ imageAlt }
 							className="hero-home__image"
-							id={ imageId }
 							src={ imageUrl }
 						/>
 					</div>


### PR DESCRIPTION
This change removes the homepage hero `srcset` attribute from the image by removing the `imageId` attribute from the `ImagePicker` component. This prevents the component from generating the `wp-image-{ID}` class needed for WP to automatically generate the `srcset` and `sizes` attributes.

This will allow editors to force the banner to always display the same image regardless of screen size or device in order to prevent blurry images in Chrome.

**Testing Instructions:**
1. Navigate to the demo page here: https://wikimediafoundation-org-develop.go-vip.co/
2. Check that the homepage hero image does not include the `wp-image-{ID}` and that the `srcset` and `sizes` attributes are missing.