### PR TITLE
Annual Report: Permit custom classnames in Accordion Item block

### DIFF
--- a/assets/src/editor/blocks/accordion-item/index.js
+++ b/assets/src/editor/blocks/accordion-item/index.js
@@ -79,10 +79,13 @@ export const settings = {
 	 * Save block markup.
 	 */
 	save: ( { attributes, context } ) => {
+		const blockProps = useBlockProps.save( {
+			className: 'accordion-item',
+		} );
 		const { fontColor, title } = attributes;
 
 		return (
-			<div className="accordion-item">
+			<div { ...blockProps }>
 				<button className="accordion-item__title" style={ fontColor && { color: fontColor } } >
 					<RichText.Content
 						className="accordion-item__title-text"


### PR DESCRIPTION
This causes the dreaded "This block contains unexpected or invalid content." notice, but clicking "attempt recovery" fixes the issue. I attempted to write a block deprecation but it was not successfully detected/applied, we may need to revisit this to clean up the warnings in a future sprint. Both versions of the block render and function correctly after this change.