### PR TITLE
Skip photos without any credit info when rendering photo credits

### DIFF
--- a/template-parts/modules/images/credit.php
+++ b/template-parts/modules/images/credit.php
@@ -47,6 +47,10 @@ if ( is_int( stripos( $license, 'Public domain' ) ) ) {
 } else {
 	$license_url = ! empty( $credit_info['license_url'] ) ? $credit_info['license_url'] : '';
 }
+
+if ( empty( $author ) && empty( $license ) && empty( $url ) ) {
+	return;
+}
 ?>
 
 <div class="attribution-item">


### PR DESCRIPTION
Allows in-house-created images without Wikimedia Commons information to be omitted from list, used for functional icons