### PR TITLE
#910: Only call coauthors links if author is available

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -166,7 +166,7 @@ function wmf_get_current_url() {
  * Adds a byline using Coauthors or WP native functions
  */
 function wmf_byline() {
-	if ( function_exists( 'coauthors_links' ) ) {
+	if ( function_exists( 'coauthors_links' ) && function_exists( 'get_coauthors' ) && ! empty( get_coauthors() ) ) {
 		return coauthors_posts_links( null, null, __( 'By ', 'shiro' ), '', false );
 	} else {
 		return get_the_author_link();


### PR DESCRIPTION
Some posts have references to invalid author IDs, which breaks CAP author lookup. If author cannot be found, skip byline.

(Accidentally fixed this while estimating how to resolve the CAP bug where it throws an error if a boolean (false) is passed in as the user record value.)

Fixes humanmade/wikimedia#910