### PR TITLE
909: Do not output profile link if link data has no URL

### DIFF
--- a/single-profile.php
+++ b/single-profile.php
@@ -69,7 +69,9 @@ while ( have_posts() ) :
 					<?php if ( ! empty( $share_links ) ) : ?>
 						<?php
 						foreach ( $share_links as $link ) :
-
+							if ( empty( $link['link'] ) ) {
+								continue;
+							}
 							?>
 					<div class="link-list mar-right">
 							<?php


### PR DESCRIPTION
For humanmade/wikimedia#909: A warning was output every time we tried to access data off of a malformed link record.

    PHP message: Warning: Undefined array key "link" in /var/www/wp-content/themes/shiro/single-profile.php

This error originates in bad content (a contact link with a name but no corresponding link URL), but we should guard against that to avoid broken links and resolve this error.