### PR TITLE
894: URL Editor Icon Does Not Display for Card Block

### DIFF
--- a/assets/src/editor/components/cta/index.js
+++ b/assets/src/editor/components/cta/index.js
@@ -20,7 +20,7 @@ import URLPicker from '../url-picker';
  * receive `undefined` which is an expected value: This is how the "remove
  * link" functionality works.
  *
- * `withFocusOutside()` is necessary here (paired with the `unstableOnFocus` attribute)
+ * `withFocusOutside()` is necessary here (paired with the `onFocus` attribute)
  * in order to show & hide the button on the toolbar when the CTA is focused
  * in the editor (or not).
  */
@@ -72,7 +72,7 @@ const CtaWithFocusOutside = withFocusOutside(
 							}
 							placeholder={ __( 'Call to action', 'shiro-admin' ) }
 							tagName="div"
-							unstableOnFocus={ () => this.setState( { showButtons: true } ) }
+							onFocus={ () => this.setState( { showButtons: true } ) }
 							value={ text }
 							onChange={ onChangeText }
 						/>


### PR DESCRIPTION
This change fixes the bug where the URL icon for editing the CTA link in the Card block was not showing up on focus.

For https://github.com/humanmade/Wikimedia/issues/894.