### PR TITLE
#894 Followup: remove deprecated unstableOnFocus attribute

### DIFF
--- a/assets/src/editor/blocks/linked-toc-item/index.js
+++ b/assets/src/editor/blocks/linked-toc-item/index.js
@@ -57,7 +57,6 @@ const LinkedTOCItemWithFocusOutside = withFocusOutside(
 						className="linked-toc__link toc__link"
 						placeholder={ __( 'Link heading', 'shiro-admin' ) }
 						tagName="span"
-						unstableOnFocus={ () => this.setState( { showButtons: true } ) }
 						value={ heading }
 						onChange={ setHeading }
 						onFocus={ () => this.setState( { showButtons: true } ) }


### PR DESCRIPTION
Since WordPress 6.3, `unstableOnFocus` is no longer needed. This component already has the proper `onFocus` callback defined, so we only need to remove the old one.

Spotted while reviewing #149 