### PR TITLE
422: Add Carousel Block Loop (Rewind) Functionality

### DIFF
--- a/assets/src/editor/blocks/carousel/block.json
+++ b/assets/src/editor/blocks/carousel/block.json
@@ -43,6 +43,10 @@
       "type": "boolean",
       "default": true
     },
+    "loop": {
+      "type": "boolean",
+      "default": false
+    },
     "autoplay": {
       "type": "boolean",
       "default": false

--- a/assets/src/editor/blocks/carousel/index.js
+++ b/assets/src/editor/blocks/carousel/index.js
@@ -197,17 +197,21 @@ export const settings = {
 			interval,
 		} = attributes;
 
+		const dataSplide = {
+			label: title,
+			perPage: perPage,
+			arrows: arrows,
+			pagination: pagination,
+			type: loop ? 'loop' : 'slide',
+			autoplay: autoplay,
+			interval: interval,
+		};
+
 		const blockProps = useBlockProps.save( {
 			className: classNames( [
 				'shiro-carousel',
 			] ),
-			'data-label': title,
-			'data-per-page': perPage,
-			'data-arrows': arrows,
-			'data-pagination': pagination,
-			'data-type': loop ? 'loop' : 'slide',
-			'data-autoplay': autoplay ? autoplay : null,
-			'data-interval': autoplay ? interval : null,
+			'data-splide': JSON.stringify( dataSplide ),
 		} );
 
 		const innerBlocksProps = useInnerBlocksProps.save( {

--- a/assets/src/editor/blocks/carousel/index.js
+++ b/assets/src/editor/blocks/carousel/index.js
@@ -198,7 +198,7 @@ export const settings = {
 			'data-per-page': perPage,
 			'data-arrows': arrows,
 			'data-pagination': pagination,
-			'data-autoplay': autoplay,
+			'data-autoplay': autoplay ? autoplay : null,
 			'data-interval': autoplay ? interval : null,
 		} );
 

--- a/assets/src/editor/blocks/carousel/index.js
+++ b/assets/src/editor/blocks/carousel/index.js
@@ -72,6 +72,7 @@ export const settings = {
 			perPage,
 			arrows,
 			pagination,
+			loop,
 			autoplay,
 			interval,
 		} = attributes;
@@ -130,6 +131,11 @@ export const settings = {
 							onChange={ ( pagination ) => setAttributes( { pagination } ) }
 						/>
 						<ToggleControl
+							label={ __( 'Loop carousel?', 'shiro-admin' ) }
+							checked={ loop }
+							onChange={ ( loop ) => setAttributes( { loop } ) }
+						/>
+						<ToggleControl
 							label={ __( 'Enable autoplay?', 'shiro-admin' ) }
 							checked={ autoplay }
 							onChange={ ( autoplay ) => setAttributes( { autoplay } ) }
@@ -186,6 +192,7 @@ export const settings = {
 			perPage,
 			arrows,
 			pagination,
+			loop,
 			autoplay,
 			interval,
 		} = attributes;
@@ -198,6 +205,7 @@ export const settings = {
 			'data-per-page': perPage,
 			'data-arrows': arrows,
 			'data-pagination': pagination,
+			'data-type': loop ? 'loop' : 'slide',
 			'data-autoplay': autoplay ? autoplay : null,
 			'data-interval': autoplay ? interval : null,
 		} );

--- a/assets/src/sass/blocks/_carousel.scss
+++ b/assets/src/sass/blocks/_carousel.scss
@@ -25,6 +25,32 @@
 		}
 	}
 
+	.splide__pagination {
+		background: rgba($wmui-color-base90, 0.5);
+		bottom: 6px;
+		left: 50%;
+		padding: 6px 12px;
+		position: absolute;
+		transform: translateX(-50%);
+		z-index: 1;
+
+		button {
+			background-color: $wmui-color-base0;
+			border: none;
+			border-radius: 6px;
+			box-shadow: $box-shadow-dialog;
+			cursor: pointer;
+			height: 12px;
+			margin: 6px;
+			opacity: 0.5;
+			width: 12px;
+
+			&.is-active {
+				opacity: 1;
+			}
+		}
+	}
+
 	// Override bottom margin from blocks used as slides
 	.splide__list > * {
 		margin-bottom: 0;
@@ -54,27 +80,9 @@
 
 		.splide__pagination {
 			background: rgba($background-color, 0.5);
-			bottom: 6px;
-			left: 50%;
-			padding: 6px 12px;
-			position: absolute;
-			transform: translateX(-50%);
-			z-index: 1;
 
 			button {
 				background-color: $text-color;
-				border: none;
-				border-radius: 6px;
-				box-shadow: $box-shadow-dialog;
-				cursor: pointer;
-				height: 12px;
-				margin: 6px;
-				opacity: 0.5;
-				width: 12px;
-
-				&.is-active {
-					opacity: 1;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
This change adds Carousel block loop (rewind) functionality and fixes the default pagination styling and the autoplay functionality which was enabled by default regardless of user settings.

<img width="282" alt="Screen Shot 2024-05-28 at 2 32 41 PM" src="https://github.com/wikimedia/shiro-wordpress-theme/assets/14046668/bff67b84-7da6-4c20-8981-7ca23f97b82d">

For https://github.com/humanmade/Wikimedia/issues/422.