### PR TITLE
Add Target Attribute to Card Block CTA Link

### DIFF
--- a/assets/src/editor/blocks/card/index.js
+++ b/assets/src/editor/blocks/card/index.js
@@ -85,6 +85,13 @@ export const settings = {
 			selector: '.content-card__call-to-action',
 			attribute: 'href',
 		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: '.content-card__call-to-action',
+			attribute: 'target',
+			default: '_self',
+		},
 	},
 
 	/**
@@ -99,6 +106,7 @@ export const settings = {
 			body,
 			linkText,
 			linkUrl,
+			linkTarget,
 			imageWidth,
 			imageHeight,
 		} = attributes;
@@ -112,6 +120,19 @@ export const settings = {
 				imageHeight: height,
 			} );
 		}, [ setAttributes ] );
+
+		const opensInNewTab = linkTarget === '_blank';
+
+		/**
+		 * Handle setting the target attribute value.
+		 */
+		const onChangeNewTab = ( opensInNewTab ) => {
+			if ( opensInNewTab ) {
+				setAttributes( { linkTarget: '_blank' } );
+			} else {
+				setAttributes( { linkTarget: '_self' } );
+			}
+		};
 
 		return (
 			<div { ...blockProps }>
@@ -136,8 +157,10 @@ export const settings = {
 						className="content-card__call-to-action arrow-link"
 						text={ linkText }
 						url={ linkUrl }
+						opensInNewTab={ opensInNewTab }
 						onChangeLink={ ( linkUrl ) => setAttributes( { linkUrl } ) }
 						onChangeText={ ( linkText ) => setAttributes( { linkText } ) }
+						onChangeNewTab={ onChangeNewTab( opensInNewTab ) }
 					/>
 				</div>
 				<ImagePicker

--- a/assets/src/editor/components/cta/index.js
+++ b/assets/src/editor/components/cta/index.js
@@ -43,8 +43,10 @@ const CtaWithFocusOutside = withFocusOutside(
 				text,
 				onChangeText,
 				onChangeLink,
+				onChangeNewTab,
 				className,
 				url,
+				opensInNewTab,
 			} = this.props;
 
 			return (
@@ -52,7 +54,9 @@ const CtaWithFocusOutside = withFocusOutside(
 					<URLPicker
 						isSelected={ showButtons }
 						url={ url }
+						opensInNewTab={ opensInNewTab }
 						onChangeLink={ onChangeLink }
+						onChangeNewTab={ onChangeNewTab }
 					/>
 					<div className={
 						classNames(
@@ -92,28 +96,34 @@ CtaWithFocusOutside.propTypes = {
 	text: PropTypes.string,
 	onChangeText: PropTypes.func.isRequired,
 	onChangeLink: PropTypes.func.isRequired,
+	onChangeNewTab: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	url: PropTypes.string,
+	opensInNewTab: PropTypes.bool,
 };
 
 /**
  * Provide a ready-made element for `save()`.
  */
-CtaWithFocusOutside.Content = ( { url, text, className, ...props } ) => {
+CtaWithFocusOutside.Content = ( { url, opensInNewTab, text, className, ...props } ) => {
 	if ( ! url ) {
 		return null;
 	}
+
+	//const newTab = opensInNewTab ? ' target="_blank" rel="noopener" ' : null;
 
 	return (
 		<a
 			className={ className }
 			href={ url }
+			/* { ...newTab } */
 			{ ...props }>{ text }</a>
 	);
 };
 
 CtaWithFocusOutside.Content.propTypes = {
 	url: PropTypes.string,
+	opensInNewTab: PropTypes.bool,
 	text: PropTypes.string,
 	className: PropTypes.string,
 };

--- a/assets/src/editor/components/url-picker/constants.js
+++ b/assets/src/editor/components/url-picker/constants.js
@@ -1,0 +1,3 @@
+export const NEW_TAB_REL = 'noreferrer noopener';
+export const NEW_TAB_TARGET = '_blank';
+//export const NOFOLLOW_REL = 'nofollow';


### PR DESCRIPTION
This PR adds the "Open in new tab" setting to the Card block CTA link settings.

**Note:** This is a draft PR and work in progress. The current setting is not yet working.