### PR TITLE
#1020: Fix profile ordering on staff page and support manual role ordering

### DIFF
--- a/inc/fields/profile.php
+++ b/inc/fields/profile.php
@@ -240,9 +240,14 @@ add_action( 'update_postmeta', 'wmf_save_user_profile', 10, 4 );
  */
 function wmf_render_role_order_list_table_column( ?string $string, string $column_name, int $term_id ) {
 	if ( $column_name === 'role_order' ) {
+		$parent_term_id = wp_get_term_taxonomy_parent_id( $term_id, 'role' );
+		if ( empty( $parent_term_id ) ) {
+			return __( 'N/A (Top level)', 'shiro-admin' );
+		}
+
 		$role_order = get_term_meta( $term_id, 'role_order', true );
 		if ( ! empty( $role_order ) ) {
-			return sprintf( '<strong>%d</strong>', (int) $role_order );
+			return sprintf( '<strong>%d</strong>', $role_order );
 		}
 	}
 	return $string;

--- a/inc/fields/profile.php
+++ b/inc/fields/profile.php
@@ -11,8 +11,8 @@
 function wmf_profile_fields() {
 	$last_name = new Fieldmanager_Textfield(
 		array(
-			'label'       => __( 'Last Name', 'shiro-admin' ),
-			'description' => __( 'This field is required to enable correct sorting via last name.', 'shiro-admin' ),
+			'label'       => __( 'Sort Name', 'shiro-admin' ),
+			'description' => __( 'Profiles are sorted on staff pages in alphabetical order based on this field.', 'shiro-admin' ),
 			'name'        => 'last_name',
 		)
 	);

--- a/inc/fields/profile.php
+++ b/inc/fields/profile.php
@@ -267,8 +267,8 @@ add_filter( 'manage_edit-role_columns', 'wmf_add_role_order_list_table_column' )
  * @return array Filtered array, with our column added.
  */
 function wmf_make_role_order_column_sortable( array $sortable_columns ) : array {
-    $sortable_columns['role_order'] = 'role_order';
-    return $sortable_columns;
+	$sortable_columns['role_order'] = 'role_order';
+	return $sortable_columns;
 }
 add_filter( 'manage_edit-role_sortable_columns', 'wmf_make_role_order_column_sortable' );
 
@@ -277,14 +277,14 @@ add_filter( 'manage_edit-role_sortable_columns', 'wmf_make_role_order_column_sor
  *
  * @param WP_Term_Query $query Term query.
  */
-function sort_role_order_column( $query ) {
-    if ( ! is_admin() ) {
-        return;
-    }
+function wmf_sort_role_order_column( $query ) {
+	if ( ! is_admin() ) {
+		return;
+	}
 
-    if ( $query->query_vars['orderby'] === 'role_order' ) {
+	if ( $query->query_vars['orderby'] === 'role_order' ) {
 		$query->query_vars['orderby'] = 'meta_value_num';
 		$query->query_vars['meta_key'] = 'role_order';
-    }
+	}
 }
-add_action( 'pre_get_terms', 'sort_role_order_column' );
+add_action( 'pre_get_terms', 'wmf_sort_role_order_column' );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -90,7 +90,6 @@ function wmf_get_header_cta_button_class() {
  * Iteratively sorts child roles as well.
  *
  * @param array $roles Keyed array of shape [ term_id => term_details_arr ].
- * @return array Sorted array.
  */
 function _wmf_sort_role_array( &$roles ) {
 	uasort( $roles, function( $a, $b) {
@@ -253,6 +252,25 @@ function wmf_get_posts_by_child_roles( int $term_id ) {
 	wp_cache_set( 'wmf_terms_list_' . $term_id, $post_list );
 
 	return $post_list;
+}
+
+/**
+ * Sort an array of profiles based on the profile's assigned last_name
+ * sorting value and return the sorted array.
+ *
+ * @param WP_Post[] $profiles Profiles to sort.
+ * @return WP_Post[] Sorted profiles.
+ */
+function wmf_sort_profiles( $profiles ) {
+	// The sort order is defined by the `last_name` meta field, which is
+	// actually exclusively used for alphabetical ordering.
+	usort( $profiles, function( $a, $b ) {
+		$last_name_a = get_post_meta( $a, 'last_name', true ) ?: 'z';
+		$last_name_b = get_post_meta( $b, 'last_name', true ) ?: 'z';
+
+		return strnatcasecmp( $last_name_a, $last_name_b );
+	} );
+	return $profiles;
 }
 
 /**

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -158,12 +158,13 @@ function wmf_get_role_posts( $term_id ) {
 	$profile_list = array_unique( $profile_list );
 
 	// Sort by last_name. Unusual profile ordering may occur if this field is not set.
-	usort( $profile_list, fn( $profile_id ) => get_post_meta( $profile_id, 'last_name', true ) );
+	usort( $profile_list, fn( $profile_id ) => get_post_meta( $profile_id, 'last_name', true ) ?: 'z' );
 
 	return array(
 		'posts' => $profile_list,
 		'name'  => $term_query->name,
 		'slug'  => $term_query->slug,
+		'order' => get_term_meta( $term_query->term_id, 'role_order', true ) ?: 0,
 	);
 }
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -89,10 +89,12 @@ function wmf_get_header_cta_button_class() {
  *
  * Iteratively sorts child roles as well.
  *
+ * NOTE: Intended for use only within role hierarchy getter functions!
+ *
  * @param array $roles Keyed array of shape [ term_id => term_details_arr ].
  */
-function _wmf_sort_role_array( &$roles ) {
-	uasort( $roles, function( $a, $b) {
+function wmf_sort_role_list( &$roles ) {
+	uasort( $roles, function( $a, $b ) {
 		$order_a = $a['order'];
 		if ( empty( $order_a ) ) {
 			$order_a = 1000;
@@ -106,7 +108,7 @@ function _wmf_sort_role_array( &$roles ) {
 
 	foreach ( $roles as $role ) {
 		if ( ! empty( $role['children'] ) ) {
-			_wmf_sort_role_array( $role['children'] );
+			wmf_sort_role_list( $role['children'] );
 		}
 	}
 }
@@ -144,7 +146,7 @@ function wmf_get_role_hierarchy( int $parent_id ) {
 		$term_array[ $child_id ] = isset( $children[ $child_id ] ) ? $children[ $child_id ] : array();
 	}
 
-	_wmf_sort_role_array( $term_array );
+	wmf_sort_role_list( $term_array );
 
 	return $term_array;
 }
@@ -247,7 +249,7 @@ function wmf_get_posts_by_child_roles( int $term_id ) {
 		}
 	}
 
-	_wmf_sort_role_array( $post_list );
+	wmf_sort_role_list( $post_list );
 
 	wp_cache_set( 'wmf_terms_list_' . $term_id, $post_list );
 

--- a/template-parts/profiles/role-list.php
+++ b/template-parts/profiles/role-list.php
@@ -11,25 +11,6 @@ if ( empty( $post_list ) ) {
 	return;
 }
 
-/**
- * Sort an array of profiles based on the profile's assigned last_name
- * sorting value and return the sorted array.
- *
- * @param WP_Post[] $profiles Profiles to sort.
- * @return WP_Post[] Sorted profiles.
- */
-function sort_profiles( $profiles ) {
-	// The sort order is defined by the `last_name` meta field, which is
-	// actually exclusively used for alphabetical ordering.
-	usort( $profiles, function( $a, $b ) {
-		$last_name_a = get_post_meta( $a, 'last_name', true ) ?: 'z';
-		$last_name_b = get_post_meta( $b, 'last_name', true ) ?: 'z';
-
-		return strnatcasecmp( $last_name_a, $last_name_b );
-	} );
-	return $profiles;
-}
-
 foreach ( $post_list as $term_id => $term_data ) {
 	$name        = ! empty( $term_data['name'] ) ? $term_data['name'] : '';
 	$description = term_description( $term_id, 'role' );
@@ -85,7 +66,7 @@ foreach ( $post_list as $term_id => $term_data ) {
 		</h3>
 		<ul class="role__staff-list">
 			<?php
-			foreach ( sort_profiles( $executives ) as $executive_id ) {
+			foreach ( wmf_sort_profiles( $executives ) as $executive_id ) {
 				get_template_part(
 					'template-parts/profiles/role',
 					'item',
@@ -126,7 +107,7 @@ foreach ( $post_list as $term_id => $term_data ) {
 			?>
 		<ul class="role__staff-list">
 			<?php
-			foreach ( sort_profiles( $term_data['posts'] ) as $term_data_post_id ) {
+			foreach ( wmf_sort_profiles( $term_data['posts'] ) as $term_data_post_id ) {
 				get_template_part(
 					'template-parts/profiles/role',
 					'item',

--- a/template-parts/profiles/role-list.php
+++ b/template-parts/profiles/role-list.php
@@ -11,6 +11,25 @@ if ( empty( $post_list ) ) {
 	return;
 }
 
+/**
+ * Sort an array of profiles based on the profile's assigned last_name
+ * sorting value and return the sorted array.
+ *
+ * @param WP_Post[] $profiles Profiles to sort.
+ * @return WP_Post[] Sorted profiles.
+ */
+function sort_profiles( $profiles ) {
+	// The sort order is defined by the `last_name` meta field, which is
+	// actually exclusively used for alphabetical ordering.
+	usort( $profiles, function( $a, $b ) {
+		$last_name_a = get_post_meta( $a, 'last_name', true ) ?: 'z';
+		$last_name_b = get_post_meta( $b, 'last_name', true ) ?: 'z';
+
+		return strnatcasecmp( $last_name_a, $last_name_b );
+	} );
+	return $profiles;
+}
+
 foreach ( $post_list as $term_id => $term_data ) {
 	$name        = ! empty( $term_data['name'] ) ? $term_data['name'] : '';
 	$description = term_description( $term_id, 'role' );
@@ -66,16 +85,7 @@ foreach ( $post_list as $term_id => $term_data ) {
 		</h3>
 		<ul class="role__staff-list">
 			<?php
-
-			// Sort executives by `last_name`, a custom meta field.
-			usort( $executives, function( $a, $b ) {
-				$last_name_a = get_post_meta( $a, 'last_name', true );
-				$last_name_b = get_post_meta( $b, 'last_name', true );
-
-				return strnatcasecmp( $last_name_a, $last_name_b );
-			} );
-
-			foreach ( $executives as $executive_id ) {
+			foreach ( sort_profiles( $executives ) as $executive_id ) {
 				get_template_part(
 					'template-parts/profiles/role',
 					'item',
@@ -97,14 +107,6 @@ foreach ( $post_list as $term_id => $term_data ) {
 		</h3>
 		<ul class="role__staff-list">
 			<?php
-			// Sort experts by `last_name`, a custom meta field.
-			usort( $experts, function( $a, $b ) {
-				$last_name_a = get_post_meta( $a, 'last_name', true );
-				$last_name_b = get_post_meta( $b, 'last_name', true );
-
-				return strnatcasecmp( $last_name_a, $last_name_b );
-			} );
-
 			foreach ( $experts as $expert_id ) {
 				get_template_part(
 					'template-parts/profiles/role',
@@ -124,7 +126,7 @@ foreach ( $post_list as $term_id => $term_data ) {
 			?>
 		<ul class="role__staff-list">
 			<?php
-			foreach ( $term_data['posts'] as $term_data_post_id ) {
+			foreach ( sort_profiles( $term_data['posts'] ) as $term_data_post_id ) {
 				get_template_part(
 					'template-parts/profiles/role',
 					'item',


### PR DESCRIPTION
The key change here is to `usort` all profiles by `last_name` meta value (which has already been coopted for sorting purposes), but importantly to treat a missing value as `z` instead of `''`. Maryana Iskander's profile already had the `last_name` key `1Iskander`, but this wasn't displaying first because (a) that section wasn't named in a way that it triggered any of the hard-coded logic in the template, and (b) Margo Lee had _no_ `last_name` set and an empty string apparently comes before `'1'` when PHP compares by `strnatcasecmp`.

To control sort order on the staff page:

1. Make sure the "Sort Name" (formerly "last name") metabox on each employee profile is filled out with values that will sort correctly, numbers before letters and letters in alphabetical order.
2. Make sure the categories themselves have a proper `role_order` value set, to make them display in the right order on the staff page. For example, the Office of the CEO could be '1', Communications could be '2', Advancement '3', etc.
    - Child categories can be ordered by adding decimal numbers, so to put "External Comms" before "Brand", you'd give External Comms `1.1`, Brand `1.2`, etcetera