### PR TITLE
#1020: Consistently sort by last_name throughout roles pages

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -191,7 +191,7 @@ function wmf_get_role_posts( $term_id ) {
 	$profile_list = array_unique( $profile_list );
 
 	// Sort by last_name. Unusual profile ordering may occur if this field is not set.
-	usort( $profile_list, fn( $profile_id ) => get_post_meta( $profile_id, 'last_name', true ) ?: 'z' );
+	$profile_list = wmf_sort_profiles( $profile_list );
 
 	return array(
 		'posts' => $profile_list,
@@ -260,8 +260,8 @@ function wmf_get_posts_by_child_roles( int $term_id ) {
  * Sort an array of profiles based on the profile's assigned last_name
  * sorting value and return the sorted array.
  *
- * @param WP_Post[] $profiles Profiles to sort.
- * @return WP_Post[] Sorted profiles.
+ * @param WP_Post[]|int[] $profiles Array of profiles (or profile post IDs) to sort.
+ * @return WP_Post[]|int[] Input array, sorted by last name.
  */
 function wmf_sort_profiles( $profiles ) {
 	// The sort order is defined by the `last_name` meta field, which is


### PR DESCRIPTION
One function within our object generation was not using the same comparator as the others, so sub-role profile ordering was not going through the same natural comparison function used elsewhere.

Fixes final bug identified while verifying WIKI-1020 on Production, see [this comment on #1020](https://github.com/humanmade/Wikimedia/issues/1020#issuecomment-2253135281)