### PR TITLE
1037/1012 [followup]: Fix hero description tag, fix SVG loading

### DIFF
--- a/.svgrrc
+++ b/.svgrrc
@@ -1,0 +1,15 @@
+{
+    "icon": true,
+    "svgoConfig": {
+        "plugins": [
+            {
+                "name": "preset-default",
+                "params": {
+                    "overrides": {
+                        "removeViewBox": false
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/assets/src/editor/blocks/banner/index.js
+++ b/assets/src/editor/blocks/banner/index.js
@@ -9,7 +9,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/banner.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/banner.svg';
 import Cta from '../../components/cta/index';
 import ImageFilter, { DEFAULT_IMAGE_FILTER } from '../../components/image-filter';
 import ImagePicker from '../../components/image-picker/index.js';

--- a/assets/src/editor/blocks/card/index.js
+++ b/assets/src/editor/blocks/card/index.js
@@ -9,7 +9,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/card.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/card.svg';
 import CallToActionPicker from '../../components/cta';
 import ImagePicker from '../../components/image-picker';
 import sharedStyles from '../../helpers/block-styles';

--- a/assets/src/editor/blocks/contact/index.js
+++ b/assets/src/editor/blocks/contact/index.js
@@ -5,8 +5,8 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/contact.svg';
-import ContactIcon from '../../../svg/individual/contact.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/contact.svg';
+import { ReactComponent as ContactIcon } from '../../../svg/individual/contact.svg';
 import CallToActionPicker from '../../components/cta';
 
 import './style.scss';

--- a/assets/src/editor/blocks/double-heading/index.js
+++ b/assets/src/editor/blocks/double-heading/index.js
@@ -11,7 +11,7 @@ import { Button, PanelBody, SelectControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/double-heading.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/double-heading.svg';
 import {
 	ensureEmptyHeading,
 	prepareHeadings,

--- a/assets/src/editor/blocks/external-link/index.js
+++ b/assets/src/editor/blocks/external-link/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
  * Local dependencies
  */
 import './style.scss';
-import ExternalLinkIcon from '../../../svg/individual/open.svg';
+import { ReactComponent as ExternalLinkIcon } from '../../../svg/individual/open.svg';
 import URLPicker from '../../components/url-picker';
 
 const ExternalLinkWithFocusOutside = withFocusOutside(

--- a/assets/src/editor/blocks/landing-page-hero/index.js
+++ b/assets/src/editor/blocks/landing-page-hero/index.js
@@ -280,7 +280,7 @@ export const settings = {
 						{ description && (
 							<RichText.Content
 								className="hero__description"
-								tagName="div"
+								tagName="p"
 								value={ description }
 							/>
 						) }

--- a/assets/src/editor/blocks/linked-toc-columns/index.js
+++ b/assets/src/editor/blocks/linked-toc-columns/index.js
@@ -1,7 +1,7 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/table-of-contents.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/table-of-contents.svg';
 
 const BLOCKS_TEMPLATE = [
 	[

--- a/assets/src/editor/blocks/mailchimp-subscribe/index.js
+++ b/assets/src/editor/blocks/mailchimp-subscribe/index.js
@@ -4,8 +4,8 @@ import { __ } from '@wordpress/i18n';
 
 import './style.scss';
 
-import BlockIcon from '../../../svg/blocks/mailchimp.svg';
-import EmailIcon from '../../../svg/individual/email.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/mailchimp.svg';
+import { ReactComponent as EmailIcon } from '../../../svg/individual/email.svg';
 
 const BLOCKS_TEMPLATE = [
 	[ 'core/heading', {

--- a/assets/src/editor/blocks/share-article/index.js
+++ b/assets/src/editor/blocks/share-article/index.js
@@ -9,8 +9,8 @@ import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { ToggleControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-import FacebookIcon from '../../../svg/individual/social-facebook.svg';
-import TwitterIcon from '../../../svg/individual/social-twitter.svg';
+import { ReactComponent as FacebookIcon } from '../../../svg/individual/social-facebook.svg';
+import { ReactComponent as TwitterIcon } from '../../../svg/individual/social-twitter.svg';
 
 export const name = 'shiro/share-article';
 

--- a/assets/src/editor/blocks/spotlight/index.js
+++ b/assets/src/editor/blocks/spotlight/index.js
@@ -9,7 +9,7 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/spotlight.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/spotlight.svg';
 import Cta from '../../components/cta/index';
 import ImageFilter, { DEFAULT_IMAGE_FILTER } from '../../components/image-filter';
 import ImagePicker from '../../components/image-picker/index.js';

--- a/assets/src/editor/blocks/stairs/index.js
+++ b/assets/src/editor/blocks/stairs/index.js
@@ -4,7 +4,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/stairs.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/stairs.svg';
 
 import './style.scss';
 

--- a/assets/src/editor/blocks/table-of-contents/deprecations.js
+++ b/assets/src/editor/blocks/table-of-contents/deprecations.js
@@ -103,8 +103,6 @@ const v1WithAriaOnButton = {
 			className: 'table-of-contents toc',
 		} );
 
-		console.log( 'trying old save' ); // eslint-disable-line
-
 		return (
 			<>
 				{ attributes.headingBlocks.length > 0 && (

--- a/assets/src/editor/blocks/toc-columns/index.js
+++ b/assets/src/editor/blocks/toc-columns/index.js
@@ -1,7 +1,7 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/table-of-contents.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/table-of-contents.svg';
 
 const BLOCKS_TEMPLATE = [
 	[

--- a/assets/src/editor/blocks/tweet-this/index.js
+++ b/assets/src/editor/blocks/tweet-this/index.js
@@ -11,7 +11,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import BlockIcon from '../../../svg/blocks/twitter.svg';
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/twitter.svg';
 
 export const
 	name = 'shiro/tweet-this',

--- a/functions.php
+++ b/functions.php
@@ -468,14 +468,17 @@ function wmf_filter_post_kses_tags( $context, $context_type ) {
 		[
 			'svg'  => [
 				'viewBox' => true,
+				'fill'    => true,
 				'width'   => true,
 				'height'  => true,
 				'class'   => true,
 				'xmlns'   => true,
 			],
 			'path' => [
-				'd'    => true,
-				'fill' => true,
+				'd'         => true,
+				'clip-rule' => true,
+				'fill'      => true,
+				'fill-rule' => true,
 			],
 			'rect' => [
 				'fill'   => true,


### PR DESCRIPTION
SVG loading became broken throughout the application after #156 due to a mismatch in how `wp-scripts`' bundled [@svgr/webpack](https://www.npmjs.com/package/@svgr/webpack) configuration differed from the prior configuration within Shiro. The primary purpose of this PR is to fix that by doing the following

- Add an SVGR configuration file [per this documentation](https://react-svgr.com/docs/configuration-files/) to set [`icon` mode](https://react-svgr.com/docs/options/#icon) for parity with the prior build, and to configured SVGO to not remove the `viewBox` attribute ([see this SO thread](https://stackoverflow.com/a/76120573))
- Change all `import SvgComponent from './path/to/icon.svg'` statements to `import { ReactComponent as SvgComponent } ...`

It also resolves an unrelated issue with the Landing Page Hero block where the `save` method did not set the correct tag for the hero description text, causing a margin issue on the frontend.

## Testing

- landing page hero issue
  - Add a landing page block, populate the Description text field, populate the CTA, and save the post. There should be visual space between the description and the link.
  - Open a page with an existing landing page block, it should display without error or (if there's any validation warning) content should be _unaffected_ by hitting "attempt recovery".
- SVG issue
  - Add a Contact block, it should render correctly in the editor and look correct after publishing
  - Open a page with a Contact block, it should render correctly in the editor and still look correct after publishing
  - (please note if you find a page where you see an Attempt Recovery button for the contact block. It's not the end of the world if we do, but it would be good to know what triggers it if present.)