### PR TITLE
1021: Fix linked ToC link item redirection issue

### DIFF
--- a/inc/editor/blocks/linked-toc-item.php
+++ b/inc/editor/blocks/linked-toc-item.php
@@ -180,7 +180,9 @@ function _toc_item_helper( $block_content, $page ) {
 	if ( ! empty( $post_id ) && is_numeric( $post_id ) ) {
 		// Update href to value of post id to ensure we have the latest permalink.
 		$href = get_permalink( $post_id );
-		$a_element->setAttribute( 'href', $href );
+		if ( ! empty( $href ) ) {
+			$a_element->setAttribute( 'href', $href );
+		}
 	}
 
 	// Check if we are on the active link.

--- a/inc/editor/blocks/linked-toc-item.php
+++ b/inc/editor/blocks/linked-toc-item.php
@@ -175,7 +175,9 @@ function _toc_item_helper( $block_content, $page ) {
 		return null;
 	}
 
-	if ( ! empty( $post_id ) ) {
+	// Double check post ID is numeric if set, sometimes that data attribute is
+	// saved as the post's permalink URL instead of a valid ID.
+	if ( ! empty( $post_id ) && is_numeric( $post_id ) ) {
 		// Update href to value of post id to ensure we have the latest permalink.
 		$href = get_permalink( $post_id );
 		$a_element->setAttribute( 'href', $href );


### PR DESCRIPTION
If the post ID property is present but invalid or if no permalink could be found for it, the prior logic would clear out the `href` and cause that item to link back to the current page.

This patch adjusts the link parsing logic to verify the post ID is numeric before trying to look up an href, and also only updates the content with the new href if a permalink URL was correctly found.

## Testing

Go to a page like https://wikimedia.vipdev.lndo.site/about/annualreport/2022-annual-report/pillar1/ and hover over each link in the table of contents. They should all point to a valid and correct URL, _e.g._ "Donors" should never point to the `/pillar1/` page itself.