### PR TITLE
1017 alignment followup

### DIFF
--- a/assets/src/sass/base/_base.scss
+++ b/assets/src/sass/base/_base.scss
@@ -72,3 +72,11 @@
 .is-layout-constrained > .alignwide {
 	max-width: var(--wp--style--global--wide-size);
 }
+
+// Some buttons may end up as inline-block, which breaks layout because
+// margin: auto does not work with that display mode.
+.is-layout-constrained > .wp-block-shiro-button.is-style-as-link {
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/assets/src/sass/base/_base.scss
+++ b/assets/src/sass/base/_base.scss
@@ -68,6 +68,10 @@
 .single-post .alignwide > .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)) {
 	max-width: unset;
 }
+// Related blog post list on post pages is wide.
+.single-post article + .block-area.is-layout-constrained > * {
+	max-width: var(--wp--style--global--wide-size);
+}
 
 .is-layout-constrained > .alignwide {
 	max-width: var(--wp--style--global--wide-size);


### PR DESCRIPTION
Two final changes

### 1. Related Posts should be "wide" width

Before | After
----- | -----
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/7231c993-7268-4790-bb01-926b00271407"> | <img width="1244" alt="image" src="https://github.com/user-attachments/assets/6614c1b4-7566-4d00-b1a6-cc048f5b9e7e">

### 2. Display-Inline buttons in main content column don't obey margins

Before | After
----- | -----
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/ba3bd2f2-f7b1-472c-9ff4-28666388c6bc"> | <img width="1247" alt="image" src="https://github.com/user-attachments/assets/8da98ce2-e974-4f6b-9282-2813c9cd063a">
