### PR TITLE
1017: Ensure embedded Blog List blocks render as wide-width in posts

### DIFF
--- a/inc/editor/blocks/blog-list.php
+++ b/inc/editor/blocks/blog-list.php
@@ -128,7 +128,10 @@ function render_block( $attributes ) : string {
 		$output = '';
 
 		foreach ( $recent_posts as $recent_post ) {
-			$output .= BlogPost\render_block( [ 'post_id' => $recent_post->ID, 'align' => 'wide' ] );
+			$output .= BlogPost\render_block( [
+				'post_id' => $recent_post->ID,
+				'align' => 'wide',
+			] );
 		}
 
 		return $output;

--- a/inc/editor/blocks/blog-list.php
+++ b/inc/editor/blocks/blog-list.php
@@ -128,7 +128,7 @@ function render_block( $attributes ) : string {
 		$output = '';
 
 		foreach ( $recent_posts as $recent_post ) {
-			$output .= BlogPost\render_block( [ 'post_id' => $recent_post->ID ] );
+			$output .= BlogPost\render_block( [ 'post_id' => $recent_post->ID, 'align' => 'wide' ] );
 		}
 
 		return $output;

--- a/inc/editor/blocks/blog-post.php
+++ b/inc/editor/blocks/blog-post.php
@@ -74,7 +74,9 @@ function render_block( $attributes ) {
 				'date'       => get_the_date(),
 				'excerpt'    => get_the_excerpt(),
 				'categories' => get_the_category(),
-				'class'      => 'blog-post' . ( ! empty( $attributes['is_featured'] ) ? ' blog-post--featured' : '' ),
+				'class'      => 'blog-post' .
+					( ! empty( $attributes['is_featured'] ) ? ' blog-post--featured' : '' ) .
+					( ( ( $attributes['align'] ?? '' ) === 'wide' ) ? ' alignwide' : '' ),
 			]
 		);
 	}


### PR DESCRIPTION
Blog List block should display wide-width in posts.

Screenshots **after**:

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/7742ec16-9df1-4ec7-a8de-f2bf160a88e1">

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/efa4ca32-61a3-4a36-bd2d-fa2a9108fdff">
