### PR TITLE
WIKI-1037: Allow opening banner block CTA in new tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
+[block.json]
+indent_style = tab
+
 [composer.json]
 indent_size = 4

--- a/assets/src/editor/blocks/banner/block.json
+++ b/assets/src/editor/blocks/banner/block.json
@@ -46,6 +46,9 @@
 			"selector": ".banner__cta",
 			"attribute": "href"
 		},
+		"openInNewTab": {
+			"type": "boolean"
+		},
 		"buttonText": {
 			"type": "string",
 			"source": "html",

--- a/assets/src/editor/blocks/banner/index.js
+++ b/assets/src/editor/blocks/banner/index.js
@@ -46,6 +46,7 @@ registerBlockType( metadata.name, {
 			imageID,
 			imageSrc,
 			imageFilter,
+			openInNewTab,
 		} = attributes;
 
 		const blockProps = useBlockProps( {
@@ -95,6 +96,8 @@ registerBlockType( metadata.name, {
 						className="banner__cta"
 						text={ buttonText }
 						url={ url }
+						openInNewTab={ openInNewTab }
+						onChangeOpenInNewTab={ ( openInNewTab ) => setAttributes( { openInNewTab } ) }
 						onChangeLink={ onChangeLink }
 						onChangeText={ onChangeText }
 					/>
@@ -128,6 +131,7 @@ registerBlockType( metadata.name, {
 			imageAlt,
 			imageID,
 			imageFilter,
+			openInNewTab,
 		} = attributes;
 
 		const blockProps = useBlockProps.save( {
@@ -149,6 +153,7 @@ registerBlockType( metadata.name, {
 					/>
 					<Cta.Content
 						className="banner__cta"
+						openInNewTab={ openInNewTab }
 						text={ buttonText }
 						url={ url }
 					/>

--- a/assets/src/editor/components/cta/index.js
+++ b/assets/src/editor/components/cta/index.js
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import { InspectorControls, RichText } from '@wordpress/block-editor';
-import { withFocusOutside, Panel, PanelRow, PanelBody, ToggleControl } from '@wordpress/components';
+import { BlockControls, InspectorControls, RichText } from '@wordpress/block-editor';
+import { withFocusOutside, Panel, PanelRow, PanelBody, ToggleControl, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import './style.scss';
@@ -83,6 +83,8 @@ const CtaWithFocusOutside = withFocusOutside(
 						isSelected={ showButtons }
 						url={ url }
 						onChangeLink={ onChangeLink }
+						openInNewTab={ openInNewTab }
+						onChangeOpenInNewTab={ onChangeOpenInNewTab }
 					/>
 					{ ! ! onChangeOpenInNewTab && (
 						<InspectorControls>

--- a/assets/src/editor/components/url-picker/index.js
+++ b/assets/src/editor/components/url-picker/index.js
@@ -61,7 +61,7 @@ function URLPicker( {
 	return (
 		<>
 			<BlockControls>
-				<ToolbarGroup>
+				{ ( ! urlIsSet || urlIsSetandSelected ) && <ToolbarGroup>
 					{ ! urlIsSet && (
 						<ToolbarButton
 							className="url-picker__link-button"
@@ -91,7 +91,7 @@ function URLPicker( {
 							onClick={ () => onChangeOpenInNewTab( ! openInNewTab ) }
 						/>
 					) }
-				</ToolbarGroup>
+				</ToolbarGroup> }
 			</BlockControls>
 			{ isSelected && (
 				<KeyboardShortcuts

--- a/assets/src/editor/components/url-picker/index.js
+++ b/assets/src/editor/components/url-picker/index.js
@@ -18,6 +18,8 @@ function URLPicker( {
 	isSelected,
 	url,
 	onChangeLink,
+	onChangeOpenInNewTab,
+	openInNewTab,
 } ) {
 	const [ isURLPickerOpen, setIsURLPickerOpen ] = useState( false );
 	const urlIsSet = !! url;
@@ -79,6 +81,14 @@ function URLPicker( {
 							shortcut={ displayShortcut.primaryShift( 'k' ) }
 							title={ __( 'Unlink' ) }
 							onClick={ removeLink }
+						/>
+					) }
+					{ ( urlIsSetandSelected && onChangeOpenInNewTab ) && (
+						<ToolbarButton
+							icon="external"
+							label={ __( 'Open in new tab', 'shiro-admin' ) }
+							isPressed={ openInNewTab }
+							onClick={ () => onChangeOpenInNewTab( ! openInNewTab ) }
 						/>
 					) }
 				</ToolbarGroup>


### PR DESCRIPTION
Addresses a remaining piece of feedback around the banner block after WIKI-1037, that the CTA should be able to open in a new tab without manually editing the markup saved in the post.

Adds an `openInNewTab` attribute to the banner block, and passes it through to the CTA, which exposes a control in the sidebar:
<img width="302" alt="image" src="https://github.com/user-attachments/assets/3c8ab402-91f5-4654-b092-8ef5efba604a">

Since the banner block has many styles and this section may be off-screen and require scrolling, I've also introduced a toolbar button to make it more obvious:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/9f79a741-33c2-437c-9287-0474d2934cde">

In action:
![banner-cta-open-in-new-tab](https://github.com/user-attachments/assets/95f16add-2778-495c-ad75-edf9fb5c8444)

