### PR TITLE
WIKI-1022: Cards Block: Enable the option to choose whether a URL opens in a new tab.

### DIFF
--- a/assets/src/editor/blocks/card/index.js
+++ b/assets/src/editor/blocks/card/index.js
@@ -85,6 +85,9 @@ export const settings = {
 			selector: '.content-card__call-to-action',
 			attribute: 'href',
 		},
+		openInNewTab: {
+			type: 'boolean'
+		},
 	},
 
 	/**
@@ -101,6 +104,7 @@ export const settings = {
 			linkUrl,
 			imageWidth,
 			imageHeight,
+			openInNewTab,
 		} = attributes;
 
 		const onSelectImage = useCallback( ( { id, src, alt, width, height } ) => {
@@ -136,6 +140,8 @@ export const settings = {
 						url={ linkUrl }
 						onChangeLink={ ( linkUrl ) => setAttributes( { linkUrl } ) }
 						onChangeText={ ( linkText ) => setAttributes( { linkText } ) }
+						openInNewTab={ openInNewTab }
+						onChangeOpenInNewTab={ ( openInNewTab ) => setAttributes( { openInNewTab } ) }
 					/>
 				</div>
 				<ImagePicker
@@ -165,6 +171,7 @@ export const settings = {
 			linkUrl,
 			imageWidth,
 			imageHeight,
+			openInNewTab,
 		} = attributes;
 
 		return (
@@ -184,6 +191,7 @@ export const settings = {
 						className="content-card__call-to-action call-to-action"
 						text={ linkText }
 						url={ linkUrl }
+						openInNewTab={ openInNewTab }
 					/>
 				</div>
 				<ImagePicker.Content


### PR DESCRIPTION
I've based this branch on 1037-banner-block-new-tab to apply the same logic to it.
<img width="298" alt="cta-link-behavior" src="https://github.com/user-attachments/assets/9a30c1e2-c34b-4a0a-be8f-2078dc78a5d9">
<img width="668" alt="anchor" src="https://github.com/user-attachments/assets/5de15e16-c374-4e25-8e9e-dda11d3e51b0">
