### PR TITLE
1010: Render share article block properly in template code

### DIFF
--- a/single.php
+++ b/single.php
@@ -80,7 +80,16 @@ while ( have_posts() ) {
 
 		<?php
 		if ( ! $has_social_share ) {
-			echo do_blocks( '<!-- wp:shiro/share-article {"enableLinkedIn":false,"enableEmail":false,"enableCopyLink":false} /-->' );
+			echo wp_kses_post(
+				render_block( [
+					'blockName' => 'shiro/share-article',
+					'attrs' => [
+						'enableLinkedIn' => false,
+						'enableEmail'    => false,
+						'enableCopyLink' => false,
+					],
+				] )
+			);
 		}
 
 		if ( ! $has_read_more_categories ) {

--- a/single.php
+++ b/single.php
@@ -80,14 +80,7 @@ while ( have_posts() ) {
 
 		<?php
 		if ( ! $has_social_share ) {
-			echo wp_kses_post(
-				\WMF\Editor\Blocks\ShareArticle\render_block(
-					array(
-						'enableTwitter'  => true,
-						'enableFacebook' => true,
-					)
-				)
-			);
+			echo do_blocks( '<!-- wp:shiro/share-article {"enableLinkedIn":false,"enableEmail":false,"enableCopyLink":false} /-->' );
 		}
 
 		if ( ! $has_read_more_categories ) {

--- a/template-parts/header/page-single.php
+++ b/template-parts/header/page-single.php
@@ -52,7 +52,16 @@ $allowed_tags = [
 			<?php endif; ?>
 
 			<?php
-			echo do_blocks( '<!-- wp:shiro/share-article {"enableLinkedIn":false,"enableEmail":false,"enableCopyLink":false} /-->' );
+			echo wp_kses_post(
+				render_block( [
+					'blockName' => 'shiro/share-article',
+					'attrs' => [
+						'enableLinkedIn' => false,
+						'enableEmail'    => false,
+						'enableCopyLink' => false,
+					],
+				] )
+			);
 			?>
 		</div>
 	</div>

--- a/template-parts/header/page-single.php
+++ b/template-parts/header/page-single.php
@@ -52,11 +52,7 @@ $allowed_tags = [
 			<?php endif; ?>
 
 			<?php
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo \WMF\Editor\Blocks\ShareArticle\render_block( [
-				'enableTwitter'  => true,
-				'enableFacebook' => true,
-			] );
+			echo do_blocks( '<!-- wp:shiro/share-article {"enableLinkedIn":false,"enableEmail":false,"enableCopyLink":false} /-->' );
 			?>
 		</div>
 	</div>


### PR DESCRIPTION
This fixes an error I missed in #175 where we were still calling the old namespace render method.
