### PR TITLE
Temporarily revert new dropdown Share button to old non-dropdown style

### DIFF
--- a/assets/src/editor/blocks/share-article/render.php
+++ b/assets/src/editor/blocks/share-article/render.php
@@ -13,6 +13,28 @@ $enable_linkedin = ( ! empty( $attributes['enableLinkedIn'] ) && wmf_get_share_u
 $enable_mail = $attributes['enableEmail'] ? true : false;
 $enable_link = $attributes['enableCopyLink'] ? true : false;
 
+// WIKI-1010: Temporarily reinstate old non-dropdown version, per review feedback.
+if ( $enable_twitter || $enable_facebook ) :
+	?>
+	<div class="share-article">
+		<?php if ( $enable_twitter ) : ?>
+			<a class="share-article__link" href="<?php echo esc_url( wmf_get_share_url( 'twitter' ) ); ?>" target="_blank" rel="noreferrer noopener">
+				<?php wmf_show_icon( 'social-twitter' ); ?>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( $enable_facebook ) : ?>
+			<a class="share-article__link" href="<?php echo esc_url( wmf_get_share_url( 'facebook' ) ); ?>" target="_blank" rel="noreferrer noopener">
+				<?php wmf_show_icon( 'social-facebook' ); ?>
+			</a>
+		<?php endif; ?>
+	</div>
+	<?php
+endif;
+
+// phpcs:disable Squiz.PHP.NonExecutableCode.Unreachable
+return;
+
 if ( $enable_twitter || $enable_facebook || $enable_linkedin || $enable_mail || $enable_link ) :
 	?>
 		<div class="share-button-container share-article">

--- a/assets/src/sass/blocks/_share-article.scss
+++ b/assets/src/sass/blocks/_share-article.scss
@@ -1,3 +1,46 @@
+.share-article {
+
+	@include global-margin-bottom;
+	display: flex;
+
+	&__link {
+		width: rem(50);
+		height: rem(50);
+		display: block;
+		line-height: rem(46);
+		text-align: center;
+		border-radius: 100%;
+		border: 1px solid #3A25FF;
+
+		&:not(:first-child) {
+			margin-left: rem(14);
+		}
+
+		&:hover,
+		&:focus {
+			svg {
+				fill: $color-primary--hover;
+				transform: scale(1.17);
+			}
+		}
+	}
+
+	svg {
+		width: rem(20);
+		height: rem(20);
+		vertical-align: middle;
+		fill: $color-primary;
+		transition: 0.3s transform;
+	}
+
+	.header-main & {
+		margin-top: rem(16);
+
+		// Don't apply default margin in header
+		margin-bottom: 0;
+	}
+}
+
 .share-button-container {
 	width: 150px;
     position: relative;
@@ -14,7 +57,7 @@
 			display: contents;
 		}
 
-		svg {	
+		svg {
 			width: rem(20);
 			height: rem(20);
 		}


### PR DESCRIPTION
Per request from Sara. The editor experience will reflect the new dropdown, but only FB and Twitter will be shown on the frontend and they will show in the classic style.

<img width="394" alt="image" src="https://github.com/user-attachments/assets/a2298b64-a308-49e7-a8fa-00317f81766b" />
