### PR TITLE
1117: UX Refresh - Update category slug classes for styles

### DIFF
--- a/assets/src/sass/helpers/mixins/_mixins-links.scss
+++ b/assets/src/sass/helpers/mixins/_mixins-links.scss
@@ -154,7 +154,7 @@
 	&.category-technology::before {
 		background-color: var(--wp--preset--color--bright-blue);
 	}
-	&.category-policy::before {
+	&.category-public-policy::before {
 		background-color: var(--wp--preset--color--bright-green);
 	}
 	&.category-community::before {
@@ -163,10 +163,10 @@
 	&.category-equity::before {
 		background-color: var(--wp--preset--color--yellow);
 	}
-	&.category-foundation::before {
+	&.category-wikimedia-foundation::before {
 		background-color: var(--wp--preset--color--red-aaa);
 	}
-	&.category-projects-initiatives::before {
+	&.category-our-projects::before {
 		background-color: var(--wp--preset--color--pink);
 	}
 }

--- a/assets/src/sass/helpers/mixins/_mixins-links.scss
+++ b/assets/src/sass/helpers/mixins/_mixins-links.scss
@@ -154,19 +154,19 @@
 	&.category-technology::before {
 		background-color: var(--wp--preset--color--bright-blue);
 	}
-	&.category-public-policy::before {
+	&.category-policy::before {
 		background-color: var(--wp--preset--color--bright-green);
 	}
-	&.category-our-community::before {
+	&.category-community::before {
 		background-color: var(--wp--preset--color--orange);
 	}
 	&.category-equity::before {
 		background-color: var(--wp--preset--color--yellow);
 	}
-	&.category-wikimedia-foundation::before {
+	&.category-foundation::before {
 		background-color: var(--wp--preset--color--red-aaa);
 	}
-	&.category-our-projects::before {
+	&.category-projects-initiatives::before {
 		background-color: var(--wp--preset--color--pink);
 	}
 }


### PR DESCRIPTION
I didn't initially realize that some of the categories exist / we might be able to keep some existing category slugs and rename them. This PR is to align the new styles with what the slugs end up being.

https://github.com/humanmade/Wikimedia/issues/1117