### PR TITLE
1103: UX refresh - fix color contrast values

### DIFF
--- a/assets/src/sass/helpers/mixins/_mixins-links.scss
+++ b/assets/src/sass/helpers/mixins/_mixins-links.scss
@@ -109,7 +109,8 @@
 		color: #233566;
 	}
 
-	&:is( .has-background:not(.has-link-color) a ):not( .blog-post a ) {
+	&:is( .has-background:not(.has-link-color) a ):not( .blog-post a ):not(.wp-block-button__link),
+	&:is( .has-text-color:not(.has-link-color) a ) {
 		color: inherit;
 		outline-color: currentColor;
 

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -1,7 +1,25 @@
 // Definitions of editor styles registered as theme supports.
 
+// Support accessible color combinations for background colors.
+$color-palette-reverse:
+	"blue",
+	"blue-aaa",
+	"green",
+	"green-aaa",
+	"purple",
+	"red",
+	"red-aaa",
+	"main",
+	"black-75";
+
+@each $color in $color-palette-reverse {
+	.has-#{$color}-background-color {
+		color: var(--wp--preset--color--base) !important;
+	}
+}
+
 // Color definitions: slug, background-color, text-color, link-color.
-$color-palette:
+$color-palette-old:
 	"base-0"           $wmui-color-base0           $wmui-color-base100 $wmui-color-accent50,
 	"base-10"          $wmui-color-base10          $wmui-color-base100 $wmui-color-accent50,
 	"base-20"          $wmui-color-base20          $wmui-color-base100 $wmui-color-blue90,
@@ -11,35 +29,22 @@ $color-palette:
 	"base-80"          $wmui-color-base80          $wmui-color-base0   $wmui-color-blue50,
 	"base-90"          $wmui-color-base90          $wmui-color-base0   $wmui-color-blue50,
 	"base-100"         $wmui-color-base100         $wmui-color-base10  $wmui-color-blue50,
-	"blue"             $wmui-color-blue            $wmui-color-base100 $wmui-color-blue90,
 	"blue-50"          $wmui-color-blue50          $wmui-color-base100 $wmui-color-blue90,
 	"blue-90"          $wmui-color-blue90          $wmui-color-base0   $wmui-color-blue50,
 	"blue-70"          $wmui-color-blue70          $wmui-color-base0   $wmui-color-base50,
 	"blue50"           $wmui-color-blue50          $wmui-color-base100 $wmui-color-base0,
-	"blue-aaa"         $wmui-color-blue-aaa        $wmui-color-base100 $wmui-color-base100,
-	"bright-blue"      $wmui-color-bright-blue     $wmui-color-base0   $wmui-color-base0,
 	"bright-blue-70"   $wmui-color-bright-blue70   $wmui-color-base0   $wmui-color-base50,
-	"bright-green"     $wmui-color-bright-green    $wmui-color-base0   $wmui-color-blue50,
 	"bright-green-70"  $wmui-color-bright-green70  $wmui-color-base0   $wmui-color-base50,
 	"dark-green"       $wmui-color-dark-green      $wmui-color-base0   $wmui-color-base50,
 	"dark-green-70"    $wmui-color-dark-green70    $wmui-color-base0   $wmui-color-base50,
-	"green"            $wmui-color-green           $wmui-color-base100 $wmui-color-base100,
-	"green-aaa"        $wmui-color-green-aaa       $wmui-color-base100 $wmui-color-base100,
 	"green-70"         $wmui-color-green70         $wmui-color-base0   $wmui-color-base50,
-	"orange"           $wmui-color-orange          $wmui-color-base0   $wmui-color-base0,
 	"orange-70"        $wmui-color-orange70        $wmui-color-base0   $wmui-color-base50,
-	"pink"             $wmui-color-pink            $wmui-color-base0   $wmui-color-base0,
 	"pink-70"          $wmui-color-pink70          $wmui-color-base0   $wmui-color-base50,
-	"purple"           $wmui-color-purple          $wmui-color-base100 $wmui-color-base100,
 	"purple-70"        $wmui-color-purple70        $wmui-color-base0   $wmui-color-base50,
-	"red"              $wmui-color-red             $wmui-color-base100 $wmui-color-base100,
-	"red-aaa"          $wmui-color-red-aaa         $wmui-color-base100 $wmui-color-base100,
 	"red-70"           $wmui-color-red70           $wmui-color-base0   $wmui-color-red50,
 	"red-50"           $wmui-color-red50           $wmui-color-base100 $wmui-color-accent90,
 	"red-90"           $wmui-color-red90           $wmui-color-base0   $wmui-color-blue50,
-	"bright-yellow"    $wmui-color-bright-yellow   $wmui-color-base0   $wmui-color-blue50,
 	"bright-yellow-70" $wmui-color-bright-yellow70 $wmui-color-base0   $wmui-color-blue50,
-	"yellow"           $wmui-color-yellow          $wmui-color-base0   $wmui-color-base0,
 	"yellow-70"        $wmui-color-yellow70        $wmui-color-base0   $wmui-color-blue50,
 	"yellow-50"        $wmui-color-yellow50        $wmui-color-base0   $wmui-color-blue50,
 	"yellow-90"        $wmui-color-yellow90        $wmui-color-base0   $wmui-color-blue50;
@@ -50,8 +55,7 @@ $color-palette:
 	--link-color: #{$wmui-color-blue50};
 }
 
-@each $color, $background-color, $text-color, $link-color in $color-palette {
-
+@each $color, $background-color, $text-color, $link-color in $color-palette-old {
 	.has-#{$color}-background-color {
 		--background-color: #{$background-color};
 		--text-color: #{$text-color};
@@ -61,10 +65,9 @@ $color-palette:
 		color: $text-color;
 		color: var(--text-color);
 
-		&.wp-block-button__link,
 		.wp-block-shiro-button.is-style-as-link {
-			color: $link-color;
-			color: var(--link-color);
+			color: $link-color !important;
+			color: var(--link-color) !important;
 
 			&::before {
 				@if $link-color == $wmui-color-base100 or $link-color == $wmui-color-blue90 or $link-color ==  $wmui-color-accent90 {

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -1,4 +1,7 @@
 // Definitions of editor styles registered as theme supports.
+.has-background > .wp-block-shiro-button.is-style-as-link::before {
+	filter: brightness(0);
+}
 
 // Support accessible color combinations for background colors.
 $color-palette-reverse:
@@ -15,6 +18,10 @@ $color-palette-reverse:
 @each $color in $color-palette-reverse {
 	.has-#{$color}-background-color {
 		color: var(--wp--preset--color--base) !important;
+
+		.wp-block-shiro-button.is-style-as-link::before {
+			filter: brightness(0) invert(1);
+		}
 	}
 }
 
@@ -70,6 +77,8 @@ $color-palette-old:
 			color: var(--link-color) !important;
 
 			&::before {
+				filter: none;
+
 				@if $link-color == $wmui-color-base100 or $link-color == $wmui-color-blue90 or $link-color ==  $wmui-color-accent90 {
 					filter: brightness(0) invert(1);
 				} @else if $link-color == $wmui-color-base0 {


### PR DESCRIPTION
- Add text color for new colors that should have reverse text
- Remove new colors from old list to prevent overlapping styling
- Remove button class from automated text colors - these will be addressed with button styles
- Add important to link styles for `.wp-block-shiro-button.is-style-as-link` for old colors, so that old instances don't change
- Filter the icon color for shiro-button link for new colors

https://github.com/humanmade/Wikimedia/issues/1103