### PR TITLE
Make sure translation props are ready before using

### DIFF
--- a/assets/src/editor/plugins/translation-status/index.js
+++ b/assets/src/editor/plugins/translation-status/index.js
@@ -10,26 +10,26 @@ const wmfIsMainSite = shiroEditorVariables.wmfIsMainSite; // eslint-disable-line
 /**
  * Fetch the post meta and pass it to our component as props.
  */
-const mapSelectToProps = ( select ) => {
+const mapSelectToProps = select => {
 	return {
-		metaInProgress: select( 'core/editor' )
-			.getEditedPostAttribute( 'meta' )
-			._translation_in_progress,
-		metaComplete: select( 'core/editor' )
-			.getEditedPostAttribute( 'meta' )
-			._translation_complete,
+		metaInProgress:
+			select( 'core/editor' )?.getEditedPostAttribute( 'meta' )
+				?._translation_in_progress,
+		metaComplete:
+			select( 'core/editor' )?.getEditedPostAttribute( 'meta' )
+				?._translation_complete,
 	};
 };
 
 /**
  * Update the component props with the post meta value.
  */
-const mapDispatchToProps = ( dispatch ) => {
+const mapDispatchToProps = dispatch => {
 	return {
 		/**
 		 * Translation in progress post meta.
 		 */
-		setmetaInProgress: ( value ) => {
+		setmetaInProgress: value => {
 			dispatch( 'core/editor' ).editPost( {
 				meta: {
 					_translation_in_progress: value,
@@ -39,7 +39,7 @@ const mapDispatchToProps = ( dispatch ) => {
 		/**
 		 * Translation complete post meta.
 		 */
-		setmetaComplete: ( value ) => {
+		setmetaComplete: value => {
 			dispatch( 'core/editor' ).editPost( {
 				meta: {
 					_translation_complete: value,
@@ -52,14 +52,14 @@ const mapDispatchToProps = ( dispatch ) => {
 /**
  * Define settings panel controls.
  */
-const MetaBlockField = ( props ) => {
+const MetaBlockField = props => {
 	return (
 		<PanelRow>
 			<div>
 				<ToggleControl
 					checked={ props.metaComplete }
 					label={ __( 'Translation completed', 'shiro-admin' ) }
-					onChange={ ( value ) => {
+					onChange={ value => {
 						if ( value && props.metaInProgress ) {
 							props.setmetaInProgress( 0 );
 						} else {
@@ -75,7 +75,9 @@ const MetaBlockField = ( props ) => {
 };
 
 const MetaBlockFieldWithData = withSelect( mapSelectToProps )( MetaBlockField );
-const MetaBlockFieldWithDataAndActions = withDispatch( mapDispatchToProps )( MetaBlockFieldWithData );
+const MetaBlockFieldWithDataAndActions = withDispatch( mapDispatchToProps )(
+	MetaBlockFieldWithData
+);
 
 registerPlugin( 'shiro-translation-status', {
 	/**


### PR DESCRIPTION
Basing this off of the feature branch, since we need it there, but it is not feature branch dependent. We could backport to main if we need this there before the feature branch is merged.

Is intended to fix the bug reported here:
https://github.com/humanmade/Wikimedia/issues/1099#issuecomment-2942528437