### PR TITLE
1136: Fix select and button styles overlap

### DIFF
--- a/assets/src/sass/base/_forms.scss
+++ b/assets/src/sass/base/_forms.scss
@@ -83,7 +83,7 @@ button {
 input[type="submit"],
 input[type="reset"],
 input[type="button"],
-button:not([class]):not([id^="mce"]):not([aria-controls]) {
+button:not([class]):not([id^="mce"]):not([aria-controls]):not([aria-expanded]):not(.dropdown-toggle + .wp-block-list button) {
 	@include button-primary-other-buttons;
 	@include button-primary();
 }

--- a/assets/src/sass/blocks/_table-of-contents.scss
+++ b/assets/src/sass/blocks/_table-of-contents.scss
@@ -40,8 +40,8 @@
 	}
 
 	&-nav {
-		margin-top: calc(var(--toc-h2-padding-top) * -1);
-		padding-top: var(--toc-h2-padding-top);
+		margin-top: calc(var(--toc-h2-padding-top) * -1) !important;
+		padding-top: var(--toc-h2-padding-top) !important;
 		pointer-events: none;
 		position: relative;
 

--- a/assets/src/sass/blocks/_table-of-contents.scss
+++ b/assets/src/sass/blocks/_table-of-contents.scss
@@ -40,6 +40,8 @@
 	}
 
 	&-nav {
+		margin-top: calc(var(--toc-h2-padding-top) * -1);
+		padding-top: var(--toc-h2-padding-top);
 		pointer-events: none;
 		position: relative;
 


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1136

Fixes problems where the buttons styles were overlapping with the select dropdown styles for the:

- ["Sort by" selector on the search page](https://wikimediafoundation-org-develop.go-vip.co/?s=sound+logo)
- [Annual report home page selector](https://wikimediafoundation-org-develop.go-vip.co/about/annualreport/)
- [Report page template for the table of contents selector on mobile](https://wikimediafoundation-org-develop.go-vip.co/about/transparency/2019-2/requests-for-user-information/)