### PR TITLE
1113: Add Contributions Section

### DIFF
--- a/assets/src/editor/blocks/interactive-card/block.json
+++ b/assets/src/editor/blocks/interactive-card/block.json
@@ -16,6 +16,9 @@
 				"background": true,
 				"text": false
 			},
+			"dimensions": {
+				"minHeight": true
+			},
 			"spacing": {
 				"padding": true,
 				"margin": [

--- a/assets/src/editor/blocks/interactive-card/block.json
+++ b/assets/src/editor/blocks/interactive-card/block.json
@@ -32,7 +32,7 @@
 		"headingText": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "h1,h2,h3,h4,h5,h6",
+			"selector": "h2,h3,h4,h5,h6",
 			"role": "content"
 		},
 		"subHeadingText": {

--- a/assets/src/editor/blocks/interactive-card/block.json
+++ b/assets/src/editor/blocks/interactive-card/block.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "shiro/interactive-card",
+	"title": "Interactive Card",
+	"category": "wikimedia",
+	"description": "Display a clickable card with animated hover reveal effect.",
+	"version": "1.0.0",
+	"textdomain": "shiro-admin",
+	"supports": {
+			"background": {
+					"backgroundImage": true,
+					"backgroundSize": false
+			},
+			"color": {
+				"background": true,
+				"text": false
+			},
+			"spacing": {
+				"padding": true,
+				"margin": [
+					"top",
+					"bottom"
+				]
+			}
+	},
+	"attributes": {
+		"headingTag": {
+			"type": "string",
+			"default": "h2"
+		},
+		"headingText": {
+			"type": "rich-text",
+			"source": "rich-text",
+			"selector": "h1,h2,h3,h4,h5,h6",
+			"role": "content"
+		},
+		"subHeadingText": {
+			"type": "string",
+			"source": "html",
+			"selector": "p"
+		}
+	},
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./style-index.css",
+	"style": "file:./style-index.css"
+}

--- a/assets/src/editor/blocks/interactive-card/edit.js
+++ b/assets/src/editor/blocks/interactive-card/edit.js
@@ -104,7 +104,7 @@ const Edit = ( props ) => {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				<div>
+				<div className="interactive-card-content">
 					<RichText
 						allowedFormats={ [ 'core/link' ] }
 						className="interactive-card-heading"
@@ -116,16 +116,17 @@ const Edit = ( props ) => {
 						} }
 					/>
 
-					<RichText
-						allowedFormats={ [ 'core/bold', 'core/italic' ] }
-						className="interactive-card-subheading"
-						placeholder={ __( 'Subheading content...', 'shiro-admin' ) }
-						tagName='p'
-						value={ subHeadingText }
-						onChange={ ( value ) => {
-							setAttributes( { subHeadingText: value } );
-						} }
-					/>
+					<div className="interactive-card-subheading">
+						<RichText
+							allowedFormats={ [ 'core/bold', 'core/italic' ] }
+							placeholder={ __( 'Subheading content...', 'shiro-admin' ) }
+							tagName='p'
+							value={ subHeadingText }
+							onChange={ ( value ) => {
+								setAttributes( { subHeadingText: value } );
+							} }
+						/>
+					</div>
 				</div>
 			</div>
 		</>

--- a/assets/src/editor/blocks/interactive-card/edit.js
+++ b/assets/src/editor/blocks/interactive-card/edit.js
@@ -1,18 +1,13 @@
 import { BlockControls, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Toolbar, ToolbarGroup } from '@wordpress/components';
-import {
-	headingLevel2,
-	headingLevel3,
-	headingLevel4,
-	headingLevel5,
-	headingLevel6
-} from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+import { controls, headingIcons } from './helpers';
 
 /**
  * @param {object} props Block properties.
  *
- * @returns {WPElement} Hero edit block component.
+ * @returns {WPElement} Interactive Card block edit component.
  */
 const Edit = ( props ) => {
 	const { attributes, setAttributes } = props;
@@ -23,32 +18,6 @@ const Edit = ( props ) => {
 	} = attributes;
 
 	const blockProps = useBlockProps();
-
-	const activeIcon = headingTag => {
-		let icon;
-
-		switch ( headingTag ) {
-			case 'h2':
-				icon = headingLevel2;
-				break;
-			case 'h3':
-				icon = headingLevel3;
-				break;
-			case 'h4':
-				icon = headingLevel4;
-				break;
-			case 'h5':
-				icon = headingLevel5;
-				break;
-			case 'h6':
-				icon = headingLevel6;
-				break;
-			default:
-				icon = headingLevel2;
-		}
-
-		return icon;
-	};
 
 	return (
 		<>
@@ -62,38 +31,12 @@ const Edit = ( props ) => {
 				>
 					<ToolbarGroup
 						label={ __( 'Change heading level', 'shiro-admin' ) }
-						icon={ activeIcon( headingTag ) }
+						icon={ headingIcons[ headingTag ] || headingLevel2 }
 						isCollapsed={ true }
-						controls={ [
-							{
-								tag: 'h2',
-								icon: headingLevel2,
-								label: __( 'Heading 2', 'shiro-admin' ),
-							},
-							{
-								tag: 'h3',
-								icon: headingLevel3,
-								label: __( 'Heading 3', 'shiro-admin' ),
-							},
-							{
-								tag: 'h4',
-								icon: headingLevel4,
-								label: __( 'Heading 4', 'shiro-admin' ),
-							},
-							{
-								tag: 'h5',
-								icon: headingLevel5,
-								label: __( 'Heading 5', 'shiro-admin' ),
-							},
-							{
-								tag: 'h6',
-								icon: headingLevel6,
-								label: __( 'Heading 6', 'shiro-admin' ),
-							}
-						].map( tag => {
+						controls={ controls.map( tag => {
 							return {
 								title: tag.label,
-								icon: tag.icon,
+								icon: headingIcons[ tag.tag ],
 								isActive: headingTag === tag.tag,
 								onClick: () => {
 									setAttributes( { headingTag: tag.tag } );
@@ -105,10 +48,10 @@ const Edit = ( props ) => {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				<div className="interactive-card-content">
+				<div className="interactive-card__content">
 					<RichText
 						allowedFormats={ [ 'core/link' ] }
-						className="interactive-card-heading is-style-h2"
+						className="interactive-card__heading"
 						placeholder={ __( 'Heading', 'shiro-admin' ) }
 						tagName={ headingTag }
 						value={ headingText }
@@ -117,7 +60,7 @@ const Edit = ( props ) => {
 						} }
 					/>
 
-					<div className="interactive-card-subheading">
+					<div className="interactive-card__subheading">
 						<RichText
 							allowedFormats={ [ 'core/bold', 'core/italic' ] }
 							placeholder={ __( 'Subheading content...', 'shiro-admin' ) }

--- a/assets/src/editor/blocks/interactive-card/edit.js
+++ b/assets/src/editor/blocks/interactive-card/edit.js
@@ -21,6 +21,7 @@ const Edit = ( props ) => {
 		headingText,
 		subHeadingText
 	} = attributes;
+
 	const blockProps = useBlockProps();
 
 	const activeIcon = headingTag => {

--- a/assets/src/editor/blocks/interactive-card/edit.js
+++ b/assets/src/editor/blocks/interactive-card/edit.js
@@ -108,7 +108,7 @@ const Edit = ( props ) => {
 				<div className="interactive-card-content">
 					<RichText
 						allowedFormats={ [ 'core/link' ] }
-						className="interactive-card-heading"
+						className="interactive-card-heading is-style-h2"
 						placeholder={ __( 'Heading', 'shiro-admin' ) }
 						tagName={ headingTag }
 						value={ headingText }

--- a/assets/src/editor/blocks/interactive-card/edit.js
+++ b/assets/src/editor/blocks/interactive-card/edit.js
@@ -1,0 +1,135 @@
+import { BlockControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import { Toolbar, ToolbarGroup } from '@wordpress/components';
+import {
+	headingLevel2,
+	headingLevel3,
+	headingLevel4,
+	headingLevel5,
+	headingLevel6
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * @param {object} props Block properties.
+ *
+ * @returns {WPElement} Hero edit block component.
+ */
+const Edit = ( props ) => {
+	const { attributes, setAttributes } = props;
+	const {
+		headingTag,
+		headingText,
+		subHeadingText
+	} = attributes;
+	const blockProps = useBlockProps();
+
+	const activeIcon = headingTag => {
+		let icon;
+
+		switch ( headingTag ) {
+			case 'h2':
+				icon = headingLevel2;
+				break;
+			case 'h3':
+				icon = headingLevel3;
+				break;
+			case 'h4':
+				icon = headingLevel4;
+				break;
+			case 'h5':
+				icon = headingLevel5;
+				break;
+			case 'h6':
+				icon = headingLevel6;
+				break;
+			default:
+				icon = headingLevel2;
+		}
+
+		return icon;
+	};
+
+	return (
+		<>
+			<BlockControls>
+				<Toolbar
+					style={ {
+						border: 'none',
+						borderRight: '1px solid',
+						padding: '0'
+					} }
+				>
+					<ToolbarGroup
+						label={ __( 'Change heading level', 'shiro-admin' ) }
+						icon={ activeIcon( headingTag ) }
+						isCollapsed={ true }
+						controls={ [
+							{
+								tag: 'h2',
+								icon: headingLevel2,
+								label: __( 'Heading 2', 'shiro-admin' ),
+							},
+							{
+								tag: 'h3',
+								icon: headingLevel3,
+								label: __( 'Heading 3', 'shiro-admin' ),
+							},
+							{
+								tag: 'h4',
+								icon: headingLevel4,
+								label: __( 'Heading 4', 'shiro-admin' ),
+							},
+							{
+								tag: 'h5',
+								icon: headingLevel5,
+								label: __( 'Heading 5', 'shiro-admin' ),
+							},
+							{
+								tag: 'h6',
+								icon: headingLevel6,
+								label: __( 'Heading 6', 'shiro-admin' ),
+							}
+						].map( tag => {
+							return {
+								title: tag.label,
+								icon: tag.icon,
+								isActive: headingTag === tag.tag,
+								onClick: () => {
+									setAttributes( { headingTag: tag.tag } );
+								},
+							}
+						} ) }
+					/>
+				</Toolbar>
+			</BlockControls>
+
+			<div { ...blockProps }>
+				<div>
+					<RichText
+						allowedFormats={ [ 'core/link' ] }
+						className="interactive-card-heading"
+						placeholder={ __( 'Heading', 'shiro-admin' ) }
+						tagName={ headingTag }
+						value={ headingText }
+						onChange={ ( value ) => {
+							setAttributes( { headingText: value } );
+						} }
+					/>
+
+					<RichText
+						allowedFormats={ [ 'core/bold', 'core/italic' ] }
+						className="interactive-card-subheading"
+						placeholder={ __( 'Subheading content...', 'shiro-admin' ) }
+						tagName='p'
+						value={ subHeadingText }
+						onChange={ ( value ) => {
+							setAttributes( { subHeadingText: value } );
+						} }
+					/>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default Edit;

--- a/assets/src/editor/blocks/interactive-card/helpers.js
+++ b/assets/src/editor/blocks/interactive-card/helpers.js
@@ -1,0 +1,39 @@
+import {
+	headingLevel2,
+	headingLevel3,
+	headingLevel4,
+	headingLevel5,
+	headingLevel6
+} from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export const headingIcons = {
+	h2: headingLevel2,
+	h3: headingLevel3,
+	h4: headingLevel4,
+	h5: headingLevel5,
+	h6: headingLevel6,
+};
+
+export const controls = [
+	{
+		tag: 'h2',
+		label: __( 'Heading 2', 'shiro-admin' ),
+	},
+	{
+		tag: 'h3',
+		label: __( 'Heading 3', 'shiro-admin' ),
+	},
+	{
+		tag: 'h4',
+		label: __( 'Heading 4', 'shiro-admin' ),
+	},
+	{
+		tag: 'h5',
+		label: __( 'Heading 5', 'shiro-admin' ),
+	},
+	{
+		tag: 'h6',
+		label: __( 'Heading 6', 'shiro-admin' ),
+	}
+];

--- a/assets/src/editor/blocks/interactive-card/index.js
+++ b/assets/src/editor/blocks/interactive-card/index.js
@@ -1,0 +1,27 @@
+/**
+ * Interactive Card block.
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+
+import { ReactComponent as BlockIcon } from '../../../svg/blocks/card.svg';
+
+import metadata from './block.json';
+import Edit from './edit';
+import Save from './save';
+
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	icon: BlockIcon,
+	edit: Edit,
+	save: Save,
+} );
+
+// Block HMR boilerplate.
+if ( module.hot ) {
+	module.hot.accept();
+	const { deregister, refresh } = require( '../../helpers/hot-blocks.js' );
+	module.hot.dispose( deregister( metadata.name ) );
+	refresh( metadata.name, module.hot.data );
+}

--- a/assets/src/editor/blocks/interactive-card/index.js
+++ b/assets/src/editor/blocks/interactive-card/index.js
@@ -4,7 +4,7 @@
 
 import { registerBlockType } from '@wordpress/blocks';
 
-import { ReactComponent as BlockIcon } from '../../../svg/blocks/card.svg';
+import { ReactComponent as CardIcon } from '../../../svg/blocks/card.svg';
 
 import metadata from './block.json';
 import Edit from './edit';
@@ -13,7 +13,7 @@ import Save from './save';
 import './style.scss';
 
 registerBlockType( metadata.name, {
-	icon: BlockIcon,
+	icon: CardIcon,
 	edit: Edit,
 	save: Save,
 } );

--- a/assets/src/editor/blocks/interactive-card/save.js
+++ b/assets/src/editor/blocks/interactive-card/save.js
@@ -17,18 +17,19 @@ const Save = ( props ) => {
 
 	return (
 		<div { ...blockProps }>
-			<div>
+			<div className="interactive-card-content">
 				<RichText.Content
 					className="interactive-card-heading"
 					tagName={ headingTag }
 					value={ headingText }
 				/>
 
-				<RichText.Content
-					className="interactive-card-subheading"
-					tagName='p'
-					value={ subHeadingText }
-				/>
+				<div className="interactive-card-subheading">
+					<RichText.Content
+						tagName='p'
+						value={ subHeadingText }
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/assets/src/editor/blocks/interactive-card/save.js
+++ b/assets/src/editor/blocks/interactive-card/save.js
@@ -19,7 +19,7 @@ const Save = ( props ) => {
 		<div { ...blockProps }>
 			<div className="interactive-card-content">
 				<RichText.Content
-					className="interactive-card-heading"
+					className="interactive-card-heading is-style-h2"
 					tagName={ headingTag }
 					value={ headingText }
 				/>

--- a/assets/src/editor/blocks/interactive-card/save.js
+++ b/assets/src/editor/blocks/interactive-card/save.js
@@ -1,0 +1,37 @@
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * @param {object} props Block properties.
+ *
+ * @returns {WPElement} Card Icon save block component.
+ */
+const Save = ( props ) => {
+	const { attributes } = props;
+	const {
+		headingTag,
+		headingText,
+		subHeadingText
+	} = attributes;
+
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			<div>
+				<RichText.Content
+					className="interactive-card-heading"
+					tagName={ headingTag }
+					value={ headingText }
+				/>
+
+				<RichText.Content
+					className="interactive-card-subheading"
+					tagName='p'
+					value={ subHeadingText }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default Save;

--- a/assets/src/editor/blocks/interactive-card/save.js
+++ b/assets/src/editor/blocks/interactive-card/save.js
@@ -3,7 +3,7 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 /**
  * @param {object} props Block properties.
  *
- * @returns {WPElement} Card Icon save block component.
+ * @returns {WPElement} Interactive Card block save component.
  */
 const Save = ( props ) => {
 	const { attributes } = props;
@@ -17,14 +17,14 @@ const Save = ( props ) => {
 
 	return (
 		<div { ...blockProps }>
-			<div className="interactive-card-content">
+			<div className="interactive-card__content">
 				<RichText.Content
-					className="interactive-card-heading is-style-h2"
+					className="interactive-card__heading"
 					tagName={ headingTag }
 					value={ headingText }
 				/>
 
-				<div className="interactive-card-subheading">
+				<div className="interactive-card__subheading">
 					<RichText.Content
 						tagName='p'
 						value={ subHeadingText }

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -105,6 +105,7 @@
 	}
 }
 
+// Editor-only styles.
 .wp-block-shiro-interactive-card.block-editor-block-list__block {
 	// Make sure heading is not taking extra height in editor.
 	.interactive-card-heading {
@@ -121,6 +122,24 @@
 	.wp-block-shiro-interactive-card {
 		.interactive-card-subheading {
 			transition: none !important;
+			grid-template-rows: 1fr !important;
+			margin-block-start: 1rem !important;
+		}
+	}
+}
+
+// Overwrite styles for browsers with no pointer devices.
+@media (hover: none), (-moz-touch-enabled: 1), (pointer:coarse) {
+	.wp-block-shiro-interactive-card {
+		.interactive-card-heading::after,
+		.interactive-card-subheading {
+			transition: none !important;
+		}
+
+		.interactive-card-heading::after {
+			opacity: 1 !important;
+			transform: scale(1) translateX(0) !important;
+			width: auto !important;
 		}
 
 		.interactive-card-subheading {

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -79,20 +79,29 @@
 }
 
 // Reveal content on hover and focus.
-.wp-block-shiro-interactive-card:not(.block-editor-block-list__block),
+.wp-block-shiro-interactive-card:not(.block-editor-block-list__block):focus-within,
+.wp-block-shiro-interactive-card:not(.block-editor-block-list__block):hover,
 .wp-block-shiro-interactive-card.is-selected {
-	&:focus-within,
-	&:hover {
-		.interactive-card-heading::after {
-			opacity: 1;
-			transform: scale(1) translateX(0);
-			width: auto;
-		}
+	.interactive-card-heading::after {
+		opacity: 1;
+		transform: scale(1) translateX(0);
+		width: auto;
+	}
 
-		.interactive-card-subheading {
-			grid-template-rows: 1fr;
-			margin-block-start: 1rem;
-		}
+	.interactive-card-subheading {
+		grid-template-rows: 1fr;
+		margin-block-start: 1rem;
+	}
+}
+
+.wp-block-shiro-interactive-card.block-editor-block-list__block {
+	// Make sure heading is not taking extra height in editor.
+	.interactive-card-heading {
+		display: inline-block;
+	}
+
+	&.is-selected .interactive-card-subheading {
+		transition: none;
 	}
 }
 

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -76,7 +76,7 @@
 	}
 }
 
-// Reveal content on hovwer and focus.
+// Reveal content on hover and focus.
 .wp-block-shiro-interactive-card:not(.block-editor-block-list__block),
 .wp-block-shiro-interactive-card.is-selected {
 	&:focus-within,

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -8,8 +8,9 @@
 	overflow: hidden;
 	position: relative;
 
-	@media only screen and ( min-width : 625px ) {
-		min-height: 310px;
+	@media only screen and ( max-width : 624px ) {
+		// Overwrite inline value.
+		min-height: auto !important;
 	}
 
 	&:focus-within {

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -98,15 +98,8 @@
 // Overwrite interactivity for reduce motion users.
 @media (prefers-reduced-motion) {
 	.wp-block-shiro-interactive-card {
-		.interactive-card-heading::after,
 		.interactive-card-subheading {
 			transition: none !important;
-		}
-
-		.interactive-card-heading::after {
-			opacity: 1 !important;
-			transform: scale(1) translateX(0) !important;
-			width: auto !important;
 		}
 
 		.interactive-card-subheading {

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -30,17 +30,20 @@
 		outline-offset: max( 2px, 0.1em );
 	}
 
-	.interactive-card-heading,
-	.interactive-card-subheading p {
+	.interactive-card__heading,
+	.interactive-card__subheading p {
 		margin-block-end: 0;
 	}
 
-	.interactive-card-heading {
+	.interactive-card__heading {
 		@include style-guide-arrow();
-		// Reset position so we can make card clickable.
-		position: static;
+		font-size: var( --wp--preset--font-size--xx-large );
+		font-weight: 700;
+		line-height: var( --wp--custom--line-height--tight );
 		// Overwrite block editor inline style that breaks parent grid.
 		min-width: auto !important;
+		// Reset position so we can make card clickable.
+		position: static;
 
 		&:focus,
 		&:hover {
@@ -60,14 +63,14 @@
 	}
 
 	// Make whole card clickable.
-	.interactive-card-heading:not(.block-editor-rich-text__editable) a::after {
+	.interactive-card__heading:not(.block-editor-rich-text__editable) a::after {
 		content: "";
 		inset: 0;
 		position: absolute;
 		z-index: 10;
 	}
 
-	.interactive-card-heading::after {
+	.interactive-card__heading::after {
 		opacity: 0;
 		transform: scale(0.95) translateX(-1rem);
 		transform-origin: center right;
@@ -76,7 +79,7 @@
 		width: 0;
 	}
 
-	.interactive-card-subheading {
+	.interactive-card__subheading {
 		display: grid;
 		grid-template-rows: 0fr;
 		transition: grid-template-rows 0.35s ease, margin 0.35s;
@@ -93,13 +96,13 @@
 .wp-block-shiro-interactive-card:not(.block-editor-block-list__block):focus-within,
 .wp-block-shiro-interactive-card:not(.block-editor-block-list__block):hover,
 .wp-block-shiro-interactive-card.is-selected {
-	.interactive-card-heading::after {
+	.interactive-card__heading::after {
 		opacity: 1;
 		transform: scale(1) translateX(0);
 		width: auto;
 	}
 
-	.interactive-card-subheading {
+	.interactive-card__subheading {
 		grid-template-rows: 1fr;
 		margin-block-start: 1rem;
 	}
@@ -108,11 +111,11 @@
 // Editor-only styles.
 .wp-block-shiro-interactive-card.block-editor-block-list__block {
 	// Make sure heading is not taking extra height in editor.
-	.interactive-card-heading {
+	.interactive-card__heading {
 		display: inline-block;
 	}
 
-	&.is-selected .interactive-card-subheading {
+	&.is-selected .interactive-card__subheading {
 		transition: none;
 	}
 }
@@ -120,7 +123,7 @@
 // Overwrite interactivity for reduce motion users.
 @media (prefers-reduced-motion) {
 	.wp-block-shiro-interactive-card {
-		.interactive-card-subheading {
+		.interactive-card__subheading {
 			transition: none !important;
 			grid-template-rows: 1fr !important;
 			margin-block-start: 1rem !important;
@@ -131,18 +134,18 @@
 // Overwrite styles for browsers with no pointer devices.
 @media (hover: none), (-moz-touch-enabled: 1), (pointer:coarse) {
 	.wp-block-shiro-interactive-card {
-		.interactive-card-heading::after,
-		.interactive-card-subheading {
+		.interactive-card__heading::after,
+		.interactive-card__subheading {
 			transition: none !important;
 		}
 
-		.interactive-card-heading::after {
+		.interactive-card__heading::after {
 			opacity: 1 !important;
 			transform: scale(1) translateX(0) !important;
 			width: auto !important;
 		}
 
-		.interactive-card-subheading {
+		.interactive-card__subheading {
 			grid-template-rows: 1fr !important;
 			margin-block-start: 1rem !important;
 		}

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -1,7 +1,14 @@
 @import "../../../sass/helpers/mixins/mixins-links";
 
 .wp-block-shiro-interactive-card {
-	border-radius: 4px;
+	border-radius: 0.25rem;
+	position: relative;
+
+	&:focus-within {
+		border-radius: 0.125rem;
+		outline: 2px solid var( --wp--preset--color--blue-aaa );
+		outline-offset: max( 2px, 0.1em );
+	}
 
 	.interactive-card-heading,
 	.interactive-card-subheading {
@@ -14,5 +21,24 @@
 
 	.interactive-card-heading {
 		@include style-guide-arrow();
+		// Reset position so we can make card clickable.
+		position: static;
+
+		a {
+			text-decoration: none !important;
+
+			&:hover,
+			&:focus-within {
+				outline: none !important;
+			}
+		}
+	}
+
+	// Make whole card clickable.
+	.interactive-card-heading:not(.block-editor-rich-text__editable) a::after {
+		content: "";
+		inset: 0;
+		position: absolute;
+		z-index: 10;
 	}
 }

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -13,6 +13,17 @@
 		min-height: auto !important;
 	}
 
+	&.has-background {
+		color: var( --wp--preset--color--base );
+	}
+
+	// Add transparent background image overlay.
+	&.has-background[style*='background-image:'] {
+		background-blend-mode: darken;
+		// Overwrite background-color set in editor.
+		background-color: rgba( 0, 0, 0, 0.6 ) !important;
+	}
+
 	&:focus-within {
 		border-radius: 0.125rem;
 		outline: 2px solid var( --wp--preset--color--blue-aaa );

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -2,6 +2,7 @@
 
 .wp-block-shiro-interactive-card {
 	border-radius: 0.25rem;
+	overflow: hidden;
 	position: relative;
 
 	&:focus-within {
@@ -11,18 +12,23 @@
 	}
 
 	.interactive-card-heading,
-	.interactive-card-subheading {
+	.interactive-card-subheading p {
 		margin-block-end: 0;
-	}
-
-	.interactive-card-subheading {
-		margin-block-start: 1rem;
 	}
 
 	.interactive-card-heading {
 		@include style-guide-arrow();
 		// Reset position so we can make card clickable.
 		position: static;
+		// Overwrite block editor inline style that breaks parent grid.
+		min-width: auto !important;
+
+		&:focus,
+		&:hover {
+			&::after {
+				font-weight: normal;
+			}
+		}
 
 		a {
 			text-decoration: none !important;
@@ -40,5 +46,79 @@
 		inset: 0;
 		position: absolute;
 		z-index: 10;
+	}
+
+	// Visually hide card content.
+	.interactive-card-content {
+		display: grid;
+		grid-template-columns: 0fr;
+		justify-content: center;
+		transition: grid-template-columns 0.35s ease, margin 0.35s;
+	}
+
+	.interactive-card-heading::after {
+		opacity: 0;
+		transform: scale(0.95) translateX(-1rem);
+		transform-origin: center right;
+		transition: all 0.25s ease-in-out;
+		transition-delay: 0.2s;
+		width: 0;
+	}
+
+	.interactive-card-subheading {
+		display: grid;
+		grid-template-rows: 0fr;
+		transition: grid-template-rows 0.35s ease, margin 0.35s;
+
+		p {
+			overflow: hidden;
+		}
+	}
+}
+
+// Reveal content on hovwer and focus.
+.wp-block-shiro-interactive-card:not(.block-editor-block-list__block),
+.wp-block-shiro-interactive-card.is-selected {
+	&:focus-within,
+	&:hover {
+		.interactive-card-content {
+			grid-template-columns: 1fr;
+		}
+
+		.interactive-card-heading::after {
+			opacity: 1;
+			transform: scale(1) translateX(0);
+			width: auto;
+		}
+
+		.interactive-card-subheading {
+			grid-template-rows: 1fr;
+			margin-block-start: 1rem;
+		}
+	}
+}
+
+// Overwrite interactivity for reduce motion users.
+@media (prefers-reduced-motion) {
+	.wp-block-shiro-interactive-card {
+		.interactive-card-content {
+			grid-template-columns: 1fr !important;
+		}
+
+		.interactive-card-heading::after,
+		.interactive-card-subheading {
+			transition: none !important;
+		}
+
+		.interactive-card-heading::after {
+			opacity: 1 !important;
+			transform: scale(1) translateX(0) !important;
+			width: auto !important;
+		}
+
+		.interactive-card-subheading {
+			grid-template-rows: 1fr !important;
+			margin-block-start: 1rem !important;
+		}
 	}
 }

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -1,0 +1,18 @@
+@import "../../../sass/helpers/mixins/mixins-links";
+
+.wp-block-shiro-interactive-card {
+	border-radius: 4px;
+
+	.interactive-card-heading,
+	.interactive-card-subheading {
+		margin-block-end: 0;
+	}
+
+	.interactive-card-subheading {
+		margin-block-start: 1rem;
+	}
+
+	.interactive-card-heading {
+		@include style-guide-arrow();
+	}
+}

--- a/assets/src/editor/blocks/interactive-card/style.scss
+++ b/assets/src/editor/blocks/interactive-card/style.scss
@@ -2,8 +2,15 @@
 
 .wp-block-shiro-interactive-card {
 	border-radius: 0.25rem;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
 	overflow: hidden;
 	position: relative;
+
+	@media only screen and ( min-width : 625px ) {
+		min-height: 310px;
+	}
 
 	&:focus-within {
 		border-radius: 0.125rem;
@@ -48,14 +55,6 @@
 		z-index: 10;
 	}
 
-	// Visually hide card content.
-	.interactive-card-content {
-		display: grid;
-		grid-template-columns: 0fr;
-		justify-content: center;
-		transition: grid-template-columns 0.35s ease, margin 0.35s;
-	}
-
 	.interactive-card-heading::after {
 		opacity: 0;
 		transform: scale(0.95) translateX(-1rem);
@@ -69,6 +68,8 @@
 		display: grid;
 		grid-template-rows: 0fr;
 		transition: grid-template-rows 0.35s ease, margin 0.35s;
+		// Ask browser to use hardware acceleration if avilable.
+		will-change: transform;
 
 		p {
 			overflow: hidden;
@@ -81,10 +82,6 @@
 .wp-block-shiro-interactive-card.is-selected {
 	&:focus-within,
 	&:hover {
-		.interactive-card-content {
-			grid-template-columns: 1fr;
-		}
-
 		.interactive-card-heading::after {
 			opacity: 1;
 			transform: scale(1) translateX(0);
@@ -101,10 +98,6 @@
 // Overwrite interactivity for reduce motion users.
 @media (prefers-reduced-motion) {
 	.wp-block-shiro-interactive-card {
-		.interactive-card-content {
-			grid-template-columns: 1fr !important;
-		}
-
 		.interactive-card-heading::after,
 		.interactive-card-subheading {
 			transition: none !important;

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -96,6 +96,7 @@ function filter_blocks( $allowed_block_types, $block_editor_context ) {
 		'shiro/unseen-intro',
 		'shiro/accordion',
 		'shiro/accordion-item',
+		'shiro/interactive-card',
 
 		// Plugin blocks
 		'gravityforms/form',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@splidejs/splide": "^4.1.4",
+        "@wordpress/icons": "^10.26.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.8.1"
       },
@@ -1812,7 +1813,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
       "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -4069,6 +4069,12 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.16",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
@@ -4080,6 +4086,25 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4925,6 +4950,39 @@
         "@playwright/test": ">=1"
       }
     },
+    "node_modules/@wordpress/element": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.26.0.tgz",
+      "integrity": "sha512-IlzQE7oVG4fuwRA5N7vhnr57kvf1HS08kwJwP+EC/olREnFEi8XOIeDa7rAEVXNAx2xeoLKQ6+K7Banp7+c6GA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.26.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.26.0.tgz",
+      "integrity": "sha512-SQfSmUOMP32duStoxvrkydCtD/ELyNXpAwkE414swo8AQAKxBJMQDYE3PZy1uZ6YCtbSX7EHHAX9G1EeoHUzgg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/eslint-plugin": {
       "version": "22.10.0",
       "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.10.0.tgz",
@@ -5015,6 +5073,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wordpress/icons": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.26.0.tgz",
+      "integrity": "sha512-7XPcJbvy4s8USfcuMxdVE6qTaEYzRv0+TZa6Epbe61HFrvaMl9X0Mr+jcCyQ7qBp4jKHfHInWfywNeYOxc5SMg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.26.0",
+        "@wordpress/primitives": "^4.26.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/jest-console": {
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.24.0.tgz",
@@ -5096,6 +5169,24 @@
       },
       "peerDependencies": {
         "prettier": ">=3"
+      }
+    },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.26.0.tgz",
+      "integrity": "sha512-vmqKlqQxyv9XDKeIntd70SpRJeU0uXWj6iQDZmmbsOcDWL3UNIOFeN5dB25vDeyoseQ+r+JNnoU+hq7cpQa/8Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.26.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -6615,7 +6706,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -6699,7 +6789,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -6727,7 +6816,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -7000,6 +7088,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7225,7 +7322,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -7768,6 +7864,12 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/cwd": {
       "version": "0.10.0",
@@ -8335,7 +8437,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -10892,7 +10993,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -11884,7 +11984,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13710,7 +13809,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -14407,7 +14505,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -15231,7 +15328,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -15309,7 +15405,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -15320,7 +15415,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -16674,7 +16768,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16686,8 +16779,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16955,8 +17046,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -17485,8 +17575,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -17637,7 +17725,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -18018,7 +18105,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19669,7 +19755,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -19998,7 +20083,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -20008,7 +20092,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@splidejs/splide": "^4.1.4",
+    "@wordpress/icons": "^10.26.0",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1"
   },

--- a/patterns/interactive-cards.php
+++ b/patterns/interactive-cards.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Title: Interactive Cards
+ * Slug: interactive-cards
+ * Categories: media
+ * Description: Add an interactive cards section.
+ * Viewport Width: 1440
+ * Inserter: true
+ * Keywords: content, card, interactive cards
+ * Block Types:
+ * Post Types:
+ * Template Types:
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
+	<!-- wp:columns {"verticalAlignment":null,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} -->
+	<div class="wp-block-columns" style="margin-bottom:var(--wp--preset--spacing--80)">
+		<!-- wp:column {"verticalAlignment":"top","width":"34%"} -->
+		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:34%">
+			<!-- wp:heading -->
+			<h2 class="wp-block-heading">Help expand<br>human knowledge</h2>
+			<!-- /wp:heading -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"top","width":"66%"} -->
+		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:66%">
+			<!-- wp:paragraph -->
+			<p>There are many different ways for you to support us. Here are some ideas for putting your skills and passions to use:</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|16"}},"layout":{"type":"grid","minimumColumnWidth":"288px"}} -->
+	<div class="wp-block-group">
+		<!-- wp:shiro/interactive-card {"style":{"spacing":{"padding":{"top":"var:preset|spacing|64","bottom":"var:preset|spacing|64","left":"var:preset|spacing|24","right":"var:preset|spacing|24"}},"dimensions":{"minHeight":"310px"}},"backgroundColor":"green-aaa"} -->
+		<div class="wp-block-shiro-interactive-card has-green-aaa-background-color has-background" style="min-height:310px;padding-top:var(--wp--preset--spacing--64);padding-right:var(--wp--preset--spacing--24);padding-bottom:var(--wp--preset--spacing--64);padding-left:var(--wp--preset--spacing--24)">
+			<div class="interactive-card-content">
+				<h2 class="interactive-card-heading is-style-h2">
+					<a href="#">Donate</a>
+				</h2>
+
+				<div class="interactive-card-subheading">
+					<p><strong>Join the 2% of readers who</strong> <strong>help</strong> <strong>fund Wikipedia</strong></p>
+				</div>
+			</div>
+		</div>
+		<!-- /wp:shiro/interactive-card -->
+
+		<!-- wp:shiro/interactive-card {"style":{"spacing":{"padding":{"top":"var:preset|spacing|64","bottom":"var:preset|spacing|64","left":"var:preset|spacing|24","right":"var:preset|spacing|24"}},"dimensions":{"minHeight":"310px"}},"backgroundColor":"red"} -->
+		<div class="wp-block-shiro-interactive-card has-red-background-color has-background" style="min-height:310px;padding-top:var(--wp--preset--spacing--64);padding-right:var(--wp--preset--spacing--24);padding-bottom:var(--wp--preset--spacing--64);padding-left:var(--wp--preset--spacing--24)">
+			<div class="interactive-card-content">
+				<h2 class="interactive-card-heading is-style-h2">
+					<a href="#">Edit</a>
+				</h2>
+
+				<div class="interactive-card-subheading">
+					<p><strong>Join the editors who</strong> <strong>update </strong><strong>Wikipedia</strong></p>
+				</div>
+			</div>
+		</div>
+		<!-- /wp:shiro/interactive-card -->
+
+		<!-- wp:shiro/interactive-card {"style":{"spacing":{"padding":{"top":"var:preset|spacing|64","bottom":"var:preset|spacing|64","left":"var:preset|spacing|24","right":"var:preset|spacing|24"}},"dimensions":{"minHeight":"310px"}},"backgroundColor":"blue-aaa"} -->
+		<div class="wp-block-shiro-interactive-card has-blue-aaa-background-color has-background" style="min-height:310px;padding-top:var(--wp--preset--spacing--64);padding-right:var(--wp--preset--spacing--24);padding-bottom:var(--wp--preset--spacing--64);padding-left:var(--wp--preset--spacing--24)">
+			<div class="interactive-card-content">
+				<h2 class="interactive-card-heading is-style-h2">
+					<a href="#">Participate</a>
+				</h2>
+
+				<div class="interactive-card-subheading">
+					<p><strong>Become a part of the Wikipedia community</strong></p>
+				</div>
+			</div>
+		</div>
+		<!-- /wp:shiro/interactive-card -->
+
+		<!-- wp:shiro/interactive-card {"style":{"spacing":{"padding":{"top":"var:preset|spacing|64","bottom":"var:preset|spacing|64","left":"var:preset|spacing|24","right":"var:preset|spacing|24"}},"dimensions":{"minHeight":"310px"}},"backgroundColor":"purple"} -->
+		<div class="wp-block-shiro-interactive-card has-purple-background-color has-background" style="min-height:310px;padding-top:var(--wp--preset--spacing--64);padding-right:var(--wp--preset--spacing--24);padding-bottom:var(--wp--preset--spacing--64);padding-left:var(--wp--preset--spacing--24)">
+			<div class="interactive-card-content">
+				<h2 class="interactive-card-heading is-style-h2">
+					<a href="#">Advocate</a>
+				</h2>
+
+				<div class="interactive-card-subheading">
+					<p><strong>Join our efforts to build a better world</strong></p>
+				</div>
+			</div>
+		</div>
+		<!-- /wp:shiro/interactive-card -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
This change adds the Contributions card CTA section.

We introduce a new block called Interactive Card that makes the bulk of this change. There is also a new block pattern named Interactive Cards that includes the content for the "Contributions section" in the design mockups.

The cards animate on focus and hover except on devices with no pointer device, or when a user selects "reduce motion" within their OS accessibility settings where the cards display all content by default.

**Todo:**
- [x] Add custom interactive card component
    - [x] Build Interactive Card block 
    - [x] Add animation on focus & hover to show/hide heading arrow and subheading
    - [x] Style the image overlay when using a background image
- [x] Build Contributions section into a block pattern
- [x] Test on mobile and adjust if necessary.
    - Preliminary tests show that on tap the cards opens up, but it follows the link immediately after.
    - We might need to display the card as expanded on touch devices.