### PR TITLE
Update Reverse Color Palette Class Rules

### DIFF
--- a/assets/src/sass/helpers/mixins/_mixins-buttons.scss
+++ b/assets/src/sass/helpers/mixins/_mixins-buttons.scss
@@ -120,6 +120,7 @@
 
 	&:active {
 		background-color: var( --link-active-color--blue );
+		border-color: var( --link-active-color--blue );
 		color: var(--wp--preset--color--base);
 	}
 
@@ -160,10 +161,12 @@
 		background-color: var(--wp--preset--color--light-bright-green);
 		border-color: var(--wp--preset--color--green-aaa);
 		color: var(--wp--preset--color--green-aaa);
+		outline-color: var(--wp--preset--color--green-aaa);
 	}
 
 	&:active {
 		background-color: var( --link-active-color--green );
+		border-color: var( --link-active-color--green );
 		color: var(--wp--preset--color--base);
 	}
 

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -75,12 +75,41 @@ $color-palette-reverse-light:
 		.is-style-transparent.has-icon .wp-block-button__link:not(:active)::before,
 		.is-style-as-link.has-icon .wp-block-button__link::before,
 		.is-style-as-arrow-link.has-icon .wp-block-button__link::before {
-			filter: brightness(0) invert(1) !important;
+			filter: brightness(0) !important;
 		}
 
 		.wp-block-button__link {
 			border-color: var(--wp--preset--color--main) !important;
 			outline-color: var(--wp--preset--color--main) !important;
+		}
+
+		&.has-base-background-color .wp-block-button__link {
+			&:hover,
+			&:focus {
+				border-color: currentColor !important;
+
+				&:is(.is-style-secondary a):not(:active) {
+					border-color: var(--wp--preset--color--blue-aaa) !important;
+				}
+
+				&:is(.is-style-secondary a):active {
+					border-color: var(--link-active-color--blue) !important;
+				}
+
+				&:is(.is-style-donate a):active {
+					border-color: var(--link-active-color--green) !important;
+					outline-color: var(--wp--preset--color--green-aaa) !important;
+				}
+			}
+
+			&:not(.is-style-tertiary a):not(.is-style-transparent a):not(:hover):not(:focus) {
+				border-color: transparent !important;
+			}
+
+			&:is(.is-style-donate a):not(:active),
+			&:is(.is-style-as-link a) {
+				outline-color: currentColor !important;
+			}
 		}
 
 		&.wp-block-separator {

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -5,7 +5,7 @@
 }
 
 // Support accessible color combinations for dark background colors.
-$color-palette-reverse-dark:
+$color-palette-dark:
 	"blue",
 	"blue-aaa",
 	"green",
@@ -16,7 +16,7 @@ $color-palette-reverse-dark:
 	"main",
 	"black-75";
 
-@each $color in $color-palette-reverse-dark {
+@each $color in $color-palette-dark {
 	.has-#{$color}-background-color {
 		color: var(--wp--preset--color--base) !important;
 
@@ -40,7 +40,7 @@ $color-palette-reverse-dark:
 }
 
 // Support accessible color combinations for light background colors.
-$color-palette-reverse-light:
+$color-palette-light:
 	"orange",
 	"yellow",
 	"pink",
@@ -66,7 +66,7 @@ $color-palette-reverse-light:
 	"border-light",
 	"border-base";
 
-@each $color in $color-palette-reverse-light {
+@each $color in $color-palette-light {
 	.has-#{$color}-background-color {
 		color: var(--wp--preset--color--main) !important;
 

--- a/assets/src/sass/utilities/_theme-supports.scss
+++ b/assets/src/sass/utilities/_theme-supports.scss
@@ -4,8 +4,8 @@
 	filter: brightness(0);
 }
 
-// Support accessible color combinations for background colors.
-$color-palette-reverse:
+// Support accessible color combinations for dark background colors.
+$color-palette-reverse-dark:
 	"blue",
 	"blue-aaa",
 	"green",
@@ -16,7 +16,7 @@ $color-palette-reverse:
 	"main",
 	"black-75";
 
-@each $color in $color-palette-reverse {
+@each $color in $color-palette-reverse-dark {
 	.has-#{$color}-background-color {
 		color: var(--wp--preset--color--base) !important;
 
@@ -31,6 +31,56 @@ $color-palette-reverse:
 		.wp-block-button__link {
 			border-color: var(--wp--preset--color--base) !important;
 			outline-color: var(--wp--preset--color--base) !important;
+		}
+
+		&.wp-block-separator {
+			color: var(--wp--preset--color--#{$color}) !important;
+		}
+	}
+}
+
+// Support accessible color combinations for light background colors.
+$color-palette-reverse-light:
+	"orange",
+	"yellow",
+	"pink",
+	"bright-blue",
+	"bright-green",
+	"bright-yellow",
+	"light-pink",
+	"light-purple",
+	"light-bright-blue",
+	"light-bright-green",
+	"lightest-pink",
+	"mid-bright-yellow",
+	"light-bright-yellow",
+	"lightest-yellow",
+	"lightest-purple",
+	"lightest-blue",
+	"lightest-green",
+	"base",
+	"black-50",
+	"black-25",
+	"black-10",
+	"black-05",
+	"border-light",
+	"border-base";
+
+@each $color in $color-palette-reverse-light {
+	.has-#{$color}-background-color {
+		color: var(--wp--preset--color--main) !important;
+
+		.wp-block-shiro-button.is-style-as-link::before,
+		.wp-block-shiro-button.is-style-as-arrow-link::before,
+		.is-style-transparent.has-icon .wp-block-button__link:not(:active)::before,
+		.is-style-as-link.has-icon .wp-block-button__link::before,
+		.is-style-as-arrow-link.has-icon .wp-block-button__link::before {
+			filter: brightness(0) invert(1) !important;
+		}
+
+		.wp-block-button__link {
+			border-color: var(--wp--preset--color--main) !important;
+			outline-color: var(--wp--preset--color--main) !important;
 		}
 
 		&.wp-block-separator {


### PR DESCRIPTION
This change updates the reverse color palette class rules to add rules for all the colors in order to prevent a nested group block from overwriting another child group block with a color background that was not previously accounted for.