### PR TITLE
1152: Enable the Mailchimp JS to fix spam flag

### DIFF
--- a/inc/editor/blocks/mailchimp-subscribe.php
+++ b/inc/editor/blocks/mailchimp-subscribe.php
@@ -24,9 +24,6 @@ function mailchimp_resources_dequeue() {
 	wp_dequeue_style( 'flick' );
 	wp_dequeue_script( 'jquery-ui-datepicker' );
 	remove_action( 'wp_head', 'mc_datepicker_load' );
-
-	// Remove the main Mailchimp JS. It doesn't seem to be needed for the form validation.
-	wp_dequeue_script( 'mailchimp_sf_main_js' );
 }
 
 /**


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1152

It turns out that the Mailchimp JS is needed, either due to a plugin update or the addition of the checkbox to the form. This restores the JS enqueue.