### PR TITLE
1112: Filter body class - add direction-rtl class

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -517,12 +517,17 @@ add_action( 'admin_menu', 'shiro_link_reusable_blocks_url' );
 
 /**
  * Add page slug as body class.
+ * Add rtl class to body if rtl styles are enqueued.
  *
  * @param array $classes An array of body class names.
  * @return array
  */
 function shiro_add_slug_body_class( $classes ) {
 	global $post;
+
+	if ( get_theme_mod( 'wmf_enable_rtl' ) ) {
+		$classes[] = 'direction-rtl';
+	}
 
 	// ignore it for search pages
 	if ( is_search() ) {


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1112

Adds direction-rtl class using the same method that RTL styles are applied, so that we can target the selector even when `is_rtl` is false.