### PR TITLE
Resolve PHPCS errors

### DIFF
--- a/assets/src/editor/blocks/blog-list/render.php
+++ b/assets/src/editor/blocks/blog-list/render.php
@@ -71,6 +71,7 @@ if ( count( $recent_posts ) > 0 ) {
 	foreach ( $recent_posts as $recent_post ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo BlogPost\render_block( [
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Need to reiterate for the dynamic array value.
 			'post_id' => $recent_post->ID,
 			'align' => 'wide',
 		] );

--- a/assets/src/editor/blocks/blog-list/render.php
+++ b/assets/src/editor/blocks/blog-list/render.php
@@ -28,7 +28,7 @@ if ( count( $excluded_categories ) > 0 ) {
 	if ( ! isset( $args['cat'] ) ) {
 		$args['cat'] = '';
 	}
-	$args['cat'] = array_reduce( $excluded_categories, function( $carry, $item ) {
+	$args['cat'] = array_reduce( $excluded_categories, function ( $carry, $item ) {
 		return $carry . ",-$item";
 	}, $args['cat'] );
 }
@@ -44,7 +44,7 @@ if ( wmf_get_current_content_language_term() !== null ) {
 		* categories to show, then we *don't* filter out non-main languages.
 		* To do so would almost certainly result in no posts being returned.
 		*/
-	$in_translated = array_reduce( $args['category__in'] ?? [], function( $collected, $cat_id ) {
+	$in_translated = array_reduce( $args['category__in'] ?? [], function ( $collected, $cat_id ) {
 		if ( $collected === true ) {
 			return true;
 		}

--- a/inc/breadcrumb-links.php
+++ b/inc/breadcrumb-links.php
@@ -34,7 +34,7 @@ function add_breadcrumb_link_meta_box() {
  *
  * @return void
  */
-function display_breadcrumb_link_meta_box( $post ) : void {
+function display_breadcrumb_link_meta_box( $post ): void {
 	$show_breadcrumb_links = get_post_meta( $post->ID, 'show_breadcrumb_links', true );
 	$breadcrumb_link_url = get_post_meta( $post->ID, 'breadcrumb_link_url', true );
 	$breadcrumb_link_title = get_post_meta( $post->ID, 'breadcrumb_link_title', true );
@@ -77,7 +77,7 @@ function display_breadcrumb_link_meta_box( $post ) : void {
  *
  * @param int $post_id The ID of the post being saved.
  */
-function save_breadcrumb_link_custom_fields( $post_id ) : void {
+function save_breadcrumb_link_custom_fields( $post_id ): void {
 	if ( ! isset( $_POST['breadcrumb_link_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['breadcrumb_link_nonce'] ), basename( __FILE__ ) ) ) {
 		return;
 	}

--- a/inc/classes/class-autoload.php
+++ b/inc/classes/class-autoload.php
@@ -39,7 +39,7 @@ class Autoload {
 	 * Sets the $path_base variable.
 	 */
 	public function __construct() {
-		$this->path_base = dirname( __FILE__ );
+		$this->path_base = __DIR__;
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Autoload {
 		$parts_count = count( $path_parts );
 
 		foreach ( $path_parts as $part ) {
-			$parts_count--;
+			--$parts_count;
 
 			$part = strtolower( str_replace( '_', '-', $part ) );
 

--- a/inc/classes/customizer/class-general.php
+++ b/inc/classes/customizer/class-general.php
@@ -655,5 +655,4 @@ class General extends Base {
 			)
 		);
 	}
-
 }

--- a/inc/classes/roles/class-base.php
+++ b/inc/classes/roles/class-base.php
@@ -117,7 +117,7 @@ class Base {
 
 		update_option( $this->version_option, $this->version );
 
-		foreach ( glob( dirname( __FILE__ ) . '/*.php' ) as $file ) {
+		foreach ( glob( __DIR__ . '/*.php' ) as $file ) {
 			if ( __FILE__ === $file ) {
 				continue; // we don't need this file.
 			}

--- a/inc/classes/translations/class-edit-posts.php
+++ b/inc/classes/translations/class-edit-posts.php
@@ -70,5 +70,4 @@ class Edit_Posts {
 			wp_dropdown_categories( $dropdown_options );
 		}
 	}
-
 }

--- a/inc/classes/translations/class-flow.php
+++ b/inc/classes/translations/class-flow.php
@@ -448,7 +448,7 @@ class Flow {
 				'default'           => 1,
 				'single'            => true,
 				'sanitize_callback' => 'absint',
-				'auth_callback'     => function() {
+				'auth_callback'     => function () {
 					return current_user_can( 'edit_posts' );
 				},
 			)
@@ -463,11 +463,10 @@ class Flow {
 				'default'           => 0,
 				'single'            => true,
 				'sanitize_callback' => 'absint',
-				'auth_callback'     => function() {
+				'auth_callback'     => function () {
 					return current_user_can( 'edit_posts' );
 				},
 			)
 		);
 	}
-
 }

--- a/inc/classes/translations/class-metaboxes.php
+++ b/inc/classes/translations/class-metaboxes.php
@@ -325,5 +325,4 @@ class Metaboxes {
 			echo '</div>';
 		}
 	}
-
 }

--- a/inc/editor/blocks/profile-list.php
+++ b/inc/editor/blocks/profile-list.php
@@ -5,7 +5,7 @@
 
 namespace WMF\Editor\Blocks\ProfileList;
 
-use \WMF\Editor\Blocks\Profile;
+use WMF\Editor\Blocks\Profile;
 
 const BLOCK_NAME = 'shiro/profile-list';
 

--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -29,7 +29,7 @@ function bootstrap() {
  * @param string $content Post content (before block parsing).
  * @return array Array of headings with anchor IDs.
  */
-function get_headings_from_post_content( string $content ) : array {
+function get_headings_from_post_content( string $content ): array {
 	// Block attributes stored in post markup are not available on their own
 	// within PHP rendering code, even once the content is parsed as blocks.
 	// DOMDocument is the most reliable tool to locate the values we want.
@@ -78,7 +78,7 @@ function get_headings_from_post_content( string $content ) : array {
  * @param string $max_depth Smallest level of heading to include.
  * @return array Array of headings nested by hierarchy.
  */
-function headings_to_nested_list( array $headings, $max_depth = 'h3' ) : array {
+function headings_to_nested_list( array $headings, $max_depth = 'h3' ): array {
 	if ( empty( $headings ) ) {
 		return [];
 	}
@@ -117,7 +117,7 @@ function headings_to_nested_list( array $headings, $max_depth = 'h3' ) : array {
  * @param array   $headings            List of headings.
  * @param boolean $render_nested_items Whether to render subitems.
  */
-function render_headings_list( $headings, $render_nested_items = true ) : void {
+function render_headings_list( $headings, $render_nested_items = true ): void {
 	if ( empty( $headings ) ) {
 		return;
 	}
@@ -150,7 +150,7 @@ function render_headings_list( $headings, $render_nested_items = true ) : void {
  * @param array  $block         Block array.
  * @return string Rendered block content.
  */
-function render_toc_block( string $block_content, array $block ) : string {
+function render_toc_block( string $block_content, array $block ): string {
 	if ( $block['blockName'] !== BLOCK_NAME ) {
 		return $block_content;
 	}

--- a/inc/editor/patterns/template-landing.php
+++ b/inc/editor/patterns/template-landing.php
@@ -6,7 +6,7 @@
 namespace WMF\Editor\Patterns\TemplateLanding;
 
 use function WMF\Editor\Patterns\TweetColumns\pattern as tweet_columns_pattern;
-use WMF\Editor\Patterns\LinkColumns as LinkColumns;
+use WMF\Editor\Patterns\LinkColumns;
 
 const NAME = 'shiro/template-landing';
 

--- a/inc/editor/patterns/template-landing.php
+++ b/inc/editor/patterns/template-landing.php
@@ -5,8 +5,8 @@
 
 namespace WMF\Editor\Patterns\TemplateLanding;
 
-use function WMF\Editor\Patterns\TweetColumns\pattern as tweet_columns_pattern;
 use WMF\Editor\Patterns\LinkColumns;
+use function WMF\Editor\Patterns\TweetColumns\pattern as tweet_columns_pattern;
 
 const NAME = 'shiro/template-landing';
 

--- a/inc/fields/profile.php
+++ b/inc/fields/profile.php
@@ -259,7 +259,7 @@ add_filter( 'manage_role_custom_column', 'wmf_render_role_order_list_table_colum
  *
  * @param array $columns Associative array of registered columns.
  */
-function wmf_add_role_order_list_table_column( array $columns ) : array {
+function wmf_add_role_order_list_table_column( array $columns ): array {
 	$columns['role_order'] = __( 'Role Order', 'shiro-admin' );
 	return $columns;
 }
@@ -271,7 +271,7 @@ add_filter( 'manage_edit-role_columns', 'wmf_add_role_order_list_table_column' )
  * @param array $sortable_columns Array of sortable columns.
  * @return array Filtered array, with our column added.
  */
-function wmf_make_role_order_column_sortable( array $sortable_columns ) : array {
+function wmf_make_role_order_column_sortable( array $sortable_columns ): array {
 	$sortable_columns['role_order'] = 'role_order';
 	return $sortable_columns;
 }

--- a/inc/post-types/post.php
+++ b/inc/post-types/post.php
@@ -16,4 +16,3 @@ function wmf_post_init() {
 	];
 }
 add_action( 'init', 'wmf_post_init' );
-

--- a/inc/shortcodes/autotweets.php
+++ b/inc/shortcodes/autotweets.php
@@ -89,7 +89,7 @@ function wmf_autotweet_callback( $atts = [], $content = '' ) {
 	$atts = shortcode_atts( $defaults, $atts, 'autotweet' );
 	static $index = 0;
 	$auto_tweet_width = 3 === (int) $atts['count'] ? 'w-32p' : 'w-48p';
-	$index++;
+	++$index;
 
 	$share_text    = get_theme_mod( 'wmf_tweet_this_copy', __( 'Tweet this', 'shiro-admin' ) );
 	$args = array(

--- a/inc/shortcodes/autotweets.php
+++ b/inc/shortcodes/autotweets.php
@@ -32,7 +32,6 @@ function wmf_autotweets_callback( $atts = [], $content = '' ) {
 			'height' => [],
 			'width' => [],
 			'alt' => [],
-			'style' => [],
 			'class' => [],
 			'style' => [],
 		],

--- a/inc/shortcodes/focus-blocks.php
+++ b/inc/shortcodes/focus-blocks.php
@@ -93,7 +93,7 @@ function wmf_focus_block_callback( $atts = [], $content = '' ) {
 	];
 	$atts = shortcode_atts( $defaults, $atts, 'focus_block' );
 	static $index = 0;
-	$index++;
+	++$index;
 
 	$image_id = custom_get_attachment_id_by_slug( $atts['img'] );
 	$image_url = $image_id ? wp_get_attachment_image_url( $image_id, array( 600, 600 ) ) : null;

--- a/inc/shortcodes/focus-blocks.php
+++ b/inc/shortcodes/focus-blocks.php
@@ -32,7 +32,6 @@ function wmf_focus_blocks_callback( $atts = [], $content = '' ) {
 			'height' => [],
 			'width' => [],
 			'alt' => [],
-			'style' => [],
 			'class' => [],
 			'style' => [],
 		],

--- a/inc/shortcodes/quotes-section.php
+++ b/inc/shortcodes/quotes-section.php
@@ -32,7 +32,6 @@ function wmf_quotes_section_callback( $atts = [], $content = '' ) {
 			'height' => [],
 			'width' => [],
 			'alt' => [],
-			'style' => [],
 			'class' => [],
 			'style' => [],
 		],

--- a/inc/shortcodes/quotes-section.php
+++ b/inc/shortcodes/quotes-section.php
@@ -89,7 +89,7 @@ function wmf_quote_box_callback( $atts = [], $content = '' ) {
 	$atts = shortcode_atts( $defaults, $atts, 'quote_box' );
 	static $index = 0;
 	$auto_tweet_width = 3 === (int) $atts['count'] ? 'w-32p' : 'w-48p';
-	$index++;
+	++$index;
 
 	ob_start();
 	?>

--- a/inc/shortcodes/wp20.php
+++ b/inc/shortcodes/wp20.php
@@ -315,8 +315,8 @@ function wmf_section_shortcode_callback( $atts = [], $content = '' ) {
 				<?php echo esc_html( $atts['title'] ) . wp_kses_post( $content ); ?>
 			</div>
 		</div>
-	<?php } else {
-		if ( $atts['reverse'] === '0' ) { ?>
+	<?php } elseif ( $atts['reverse'] === '0' ) {
+		?>
 			<div id="<?php echo esc_attr( $id ); ?>" class="<?php echo esc_attr( $classes ); ?>">
 				<div class="flex flex-medium flex-space-between <?php echo esc_attr( $atts['class'] ); ?>">
 					<div class="w-48p mod-margin-bottom_xs"><?php echo wp_kses_post( $content ); ?></div>
@@ -342,9 +342,9 @@ function wmf_section_shortcode_callback( $atts = [], $content = '' ) {
 					<div class="w-48p mod-margin-bottom_xs"><?php echo wp_kses_post( $content ); ?></div>
 				</div>
 			</div>
-	<?php }
-	}
-	return (string) ob_get_clean();
+		<?php 
+		}
+		return (string) ob_get_clean();
 }
 add_shortcode( 'wmf_section', 'wmf_section_shortcode_callback' );
 

--- a/inc/taxonomy-content-language.php
+++ b/inc/taxonomy-content-language.php
@@ -143,7 +143,7 @@ function wmf_add_default_content_language( int $post_ID ): void {
  * @param \WP_Query $query Query object to filter.
  * @return void
  */
-function wmf_filter_posts_by_content_language( WP_Query $query ) : void {
+function wmf_filter_posts_by_content_language( WP_Query $query ): void {
 
 	// Don't filter the admin.
 	if ( is_admin() ) {
@@ -288,12 +288,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			$terms = wp_get_post_terms( $post_id, 'content-language' );
 			if ( is_wp_error( $terms ) ) {
 				WP_CLI::error( "$post_id - Cannot find content-language taxonomy!" );
-				$count++;
+				++$count;
 				continue;
 			}
 			if ( count( $terms ) > 0 ) {
 				WP_CLI::success( "$post_id - Has languages; no need to update." );
-				$count++;
+				++$count;
 				continue;
 			}
 
@@ -301,7 +301,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				wmf_add_default_content_language( $post_id );
 			}
 			WP_CLI::success( "$post_id - Updated content-language terms!" );
-			$count++;
+			++$count;
 			unset( $terms );
 		}
 		wp_defer_term_counting( false );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,7 @@
 
 	<!-- What to scan -->
 	<file>.</file>
+	<exclude-pattern>assets/dist</exclude-pattern>
 	<exclude-pattern>tests/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
 	<exclude-pattern>node_modules/</exclude-pattern>

--- a/template-parts/modules/mu/text-home.php
+++ b/template-parts/modules/mu/text-home.php
@@ -40,7 +40,7 @@ $h3_class = is_front_page() ? 'no-border' : '';
 	<?php
 	if ( ! empty( $links ) ) :
 		foreach ( $links as $link ) :
-			$count++;
+			++$count;
 
 			$class = ( $count > 1 && $count === $link_count ) ? 'mar-bottom_lg' : 'mar-bottom';
 			?>

--- a/template-parts/modules/mu/text.php
+++ b/template-parts/modules/mu/text.php
@@ -39,7 +39,7 @@ $h3_class = is_front_page() ? 'no-border' : '';
 	<?php
 	if ( ! empty( $links ) ) :
 		foreach ( $links as $link ) :
-			$count++;
+			++$count;
 
 			$class = ( $count > 1 && $count === $link_count ) ? 'mar-bottom_lg' : 'mar-bottom';
 			?>

--- a/template-parts/modules/mu/ungrid.php
+++ b/template-parts/modules/mu/ungrid.php
@@ -38,7 +38,7 @@ $h3_class = is_front_page() ? 'no-border' : '';
 		<?php
 		if ( ! empty( $links ) ) :
 			foreach ( $links as $link ) :
-				$count++;
+				++$count;
 
 				$class = ( $count > 1 && $count === $link_count ) ? 'mar-bottom_lg' : 'mar-bottom';
 				?>

--- a/template-parts/page/page-related-posts.php
+++ b/template-parts/page/page-related-posts.php
@@ -21,5 +21,3 @@ get_template_part(
 		'posts'                  => $related_posts,
 	)
 );
-
-

--- a/template-parts/profiles/role-list.php
+++ b/template-parts/profiles/role-list.php
@@ -13,7 +13,7 @@ if ( empty( $post_list ) ) {
 
 foreach ( $post_list as $term_id => $term_data ) {
 	$name        = ! empty( $term_data['name'] ) ? $term_data['name'] : '';
-	$description = term_description( $term_id, 'role' );
+	$description = term_description( $term_id );
 	$button      = get_term_meta( $term_id, 'role_button', true );
 	$executives  = get_term_meta( $term_id, 'role_executive', true );
 	$experts     = get_term_meta( $term_id, 'role_experts', true );
@@ -127,7 +127,7 @@ foreach ( $post_list as $term_id => $term_data ) {
 				<?php
 				foreach ( $term_data['children'] as $child_term_id => $child_term_data ) {
 					$name        = ! empty( $child_term_data['name'] ) ? $child_term_data['name'] : '';
-					$description = term_description( $child_term_id, 'role' );
+					$description = term_description( $child_term_id );
 
 					if ( empty( $child_term_data['posts'] ) ) {
 						continue;


### PR DESCRIPTION
While reviewing [the failed PHP code actions](https://github.com/wikimedia/shiro-wordpress-theme/actions/runs/16806634309/job/47600668871) in this repository, I realized that while we've been addressing PHPCS changes in each file we edit, we still have a variety of warnings and errors throughout the codebase. This PR runs `phpcbf` to resolve all automatically-fixable formatting changes, and then manually resolves four specific errors flagged by the code checks.

I have not addressed warnings at this time; there are 17 warnings remaining in the codebase following this PR, mostly relating to the use of reserved property names (calling something `$string` is usually discouraged, etc) and unused parameters. These can be addressed later, or when we touch those files next.

This diff is most effectively viewed without the whitespace changes, which can be done with this link: TK