### PR TITLE
Guard against unset Slide.slide variable in homepage carousel

### DIFF
--- a/assets/src/scripts/block-hero-home.js
+++ b/assets/src/scripts/block-hero-home.js
@@ -115,8 +115,10 @@ function fadeInCurrentHeading( block ) {
  * @param {object} Slide sub-component that is visible.
  * @param {HTMLElement} Slide.slide Element holding current slide.
  */
-export function slideVisible( { slide } ) {
-	startRotatingHeadings( slide );
+export function slideVisible( Slide ) {
+	if ( Slide?.slide ) {
+		startRotatingHeadings( Slide.slide );
+	}
 }
 
 /**
@@ -125,8 +127,10 @@ export function slideVisible( { slide } ) {
  * @param {object} Slide sub-component that is visible.
  * @param {HTMLElement} Slide.slide Element holding current slide.
  */
-export function slideHidden( { slide } ) {
-	stopRotatingHeadings( slide );
+export function slideHidden( Slide ) {
+	if ( Slide?.slide ) {
+		stopRotatingHeadings( Slide.slide );
+	}
 }
 
 /**


### PR DESCRIPTION
While validating the deploy on August 7 we briefly observed a JS error that `{ slide }` could not be destructured from a null reference. While we suspect this was a transient situation due to the rollout of the updated page content and markup, we _could_ add an existence check here prior to destructuring to be more confident the object exists.