### PR TITLE
Fix additional PHPCS warnings

### DIFF
--- a/inc/classes/class-autoload.php
+++ b/inc/classes/class-autoload.php
@@ -45,6 +45,8 @@ class Autoload {
 	/**
 	 * Callback for the spl_autoload_register function.
 	 *
+	 * phpcs:disable Universal.NamingConventions.NoReservedKeywordParameterNames.classFound
+	 *
 	 * @param string $class The class being checked.
 	 */
 	public function callback( $class ) {

--- a/inc/classes/images/class-credits.php
+++ b/inc/classes/images/class-credits.php
@@ -108,17 +108,12 @@ class Credits {
 	/**
 	 * Adds the requested image ID to the list of IDs if not previously set.
 	 *
-	 * @param bool $bool     Override bool value used to replace downsize logic.
-	 * @param int  $image_id The image ID.
-	 *
-	 * @return mixed
+	 * @param int $image_id The image ID.
 	 */
-	public function set_id( $bool, $image_id ) {
+	public function set_id( $image_id ) {
 		if ( true !== $this->pause && ! in_array( $image_id, $this->image_ids, true ) ) {
 			$this->image_ids[] = $image_id;
 		}
-
-		return $bool;
 	}
 
 	/**
@@ -177,7 +172,7 @@ class Credits {
 				continue;
 			}
 
-			$this->set_id( true, $image_id );
+			$this->set_id( $image_id );
 		}
 	}
 

--- a/inc/classes/images/class-credits.php
+++ b/inc/classes/images/class-credits.php
@@ -119,13 +119,11 @@ class Credits {
 	/**
 	 * Adds the requested image ID based on the attachment source, if not previously set.
 	 *
-	 * @param array|false  $image         Array of image data, or boolean false if no image is available.
-	 * @param int          $attachment_id Image attachment ID.
-	 * @param string|int[] $size          Image size (any registered size name, or [ width, height ] array).
-	 * @param bool         $icon          Whether to fall back to an icon mime type.
+	 * @param array|false $image         Array of image data, or boolean false if no image is available.
+	 * @param int         $attachment_id Image attachment ID.
 	 * @return array|false Unchanged $image.
 	 */
-	public function set_id_from_att_src( $image, $attachment_id, $size, $icon ) {
+	public function set_id_from_att_src( $image, $attachment_id ) {
 		if ( true !== $this->pause && ! in_array( $attachment_id, $this->image_ids, true ) ) {
 			$this->image_ids[] = $attachment_id;
 		}

--- a/inc/classes/translations/class-edit-posts.php
+++ b/inc/classes/translations/class-edit-posts.php
@@ -22,7 +22,8 @@ class Edit_Posts {
 	 * Edit_Posts constructor.
 	 */
 	public function __construct() {
-		$this->translation_status = isset( $_GET['translation-status'] ) ? sanitize_title( wp_unslash( $_GET['translation-status'] ) ) : ''; // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected,WordPress.CSRF.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$this->translation_status = isset( $_GET['translation-status'] ) ? sanitize_title( wp_unslash( $_GET['translation-status'] ) ) : '';
 	}
 
 	/**

--- a/inc/classes/translations/class-flow.php
+++ b/inc/classes/translations/class-flow.php
@@ -198,13 +198,11 @@ class Flow {
 	/**
 	 * Define which post meta to sync to remote site.
 	 *
-	 * @param string[] $keys    Keys array.
-	 * @param unknown  $context Context.
-	 * @param unknown  $post    Current post.
+	 * @param string[] $keys Keys array.
 	 *
 	 * @return string[]
 	 */
-	public static function sync_meta( $keys, $context, $post ) {
+	public static function sync_meta( $keys ) {
 		return array_merge(
 			$keys,
 			[

--- a/inc/classes/translations/class-flow.php
+++ b/inc/classes/translations/class-flow.php
@@ -301,6 +301,8 @@ class Flow {
 	/**
 	 * Remove any values that are numeric.
 	 *
+	 * phpcs:disable Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound
+	 *
 	 * @param array $array The array to parse.
 	 *
 	 * @return array

--- a/inc/classes/translations/class-metaboxes.php
+++ b/inc/classes/translations/class-metaboxes.php
@@ -42,13 +42,13 @@ class Metaboxes {
 	/**
 	 * Initiates the set_translation_meta_opts method.
 	 *
-	 * @param string              $out    The output.
-	 * @param \Fieldmanager_Field $object The Fieldmanager_Field object.
+	 * @param string              $out   The output.
+	 * @param \Fieldmanager_Field $field The Fieldmanager_Field object.
 	 *
 	 * @return mixed
 	 */
-	public static function fm_element_markup_end( $out, $object ) {
-		static::get_instance()->set_translation_meta_opts( $object );
+	public static function fm_element_markup_end( $out, $field ) {
+		static::get_instance()->set_translation_meta_opts( $field );
 
 		return $out;
 	}
@@ -56,11 +56,11 @@ class Metaboxes {
 	/**
 	 * Sets the $translation_meta_opts property.
 	 *
-	 * @param \Fieldmanager_Field $object The Fieldmanager_Field object.
+	 * @param \Fieldmanager_Field $field The Fieldmanager_Field object.
 	 */
-	public function set_translation_meta_opts( $object ) {
-		if ( ! empty( $object->name ) ) {
-			$this->translation_meta_opts[ $object->name ] = $object;
+	public function set_translation_meta_opts( $field ) {
+		if ( ! empty( $field->name ) ) {
+			$this->translation_meta_opts[ $field->name ] = $field;
 		}
 	}
 

--- a/inc/fields/profile.php
+++ b/inc/fields/profile.php
@@ -233,12 +233,12 @@ add_action( 'update_postmeta', 'wmf_save_user_profile', 10, 4 );
 /**
  * Show the configured row-order meta value in the term list table.
  *
- * @param ?string $string      Column contents.
+ * @param ?string $content     Column contents.
  * @param string  $column_name Name of column.
  * @param int     $term_id     ID of term being rendered.
  * @return ?string Filtered contents string.
  */
-function wmf_render_role_order_list_table_column( ?string $string, string $column_name, int $term_id ) {
+function wmf_render_role_order_list_table_column( ?string $content, string $column_name, int $term_id ) {
 	if ( $column_name === 'role_order' ) {
 		$parent_term_id = wp_get_term_taxonomy_parent_id( $term_id, 'role' );
 		if ( empty( $parent_term_id ) ) {
@@ -250,7 +250,7 @@ function wmf_render_role_order_list_table_column( ?string $string, string $colum
 			return sprintf( '<strong>%d</strong>', $role_order );
 		}
 	}
-	return $string;
+	return $content;
 }
 add_filter( 'manage_role_custom_column', 'wmf_render_role_order_list_table_column', 10, 3 );
 

--- a/inc/shortcodes/facts.php
+++ b/inc/shortcodes/facts.php
@@ -15,11 +15,10 @@
 /**
  * Define a [wmf_fact] wrapper shortcode that creates a dumb HTML wrapper.
  *
- * @param array  $atts    Shortcode attributes array.
- * @param string $content Content wrapped by shortcode.
+ * @param array $atts Shortcode attributes array.
  * @return string Rendered shortcode output.
  */
-function wmf_fact_shortcode_callback( $atts, $content = '' ) {
+function wmf_fact_shortcode_callback( $atts ) {
 	$defaults = [
 		'value' => 0,
 		'label' => '',

--- a/inc/shortcodes/wp20.php
+++ b/inc/shortcodes/wp20.php
@@ -12,11 +12,10 @@
 /**
  * Define a [symbol_grid] shortcode that renders a grid of images and text.
  *
- * @param array  $atts Shortcode attributes array.
- * @param string $content Content wrapped by shortcode.
+ * @param array $atts Shortcode attributes array.
  * @return string Rendered shortcode output.
  */
-function wmf_symbols_grid_callback( $atts = [], $content = '' ) {
+function wmf_symbols_grid_callback( $atts = [] ) {
 	$defaults = [
 		'title' => '',
 		'text' => '',
@@ -342,7 +341,7 @@ function wmf_section_shortcode_callback( $atts = [], $content = '' ) {
 					<div class="w-48p mod-margin-bottom_xs"><?php echo wp_kses_post( $content ); ?></div>
 				</div>
 			</div>
-		<?php 
+		<?php
 		}
 		return (string) ob_get_clean();
 }

--- a/inc/stories.php
+++ b/inc/stories.php
@@ -19,9 +19,8 @@ function init() {
  * @param int       $object_id  ID of the object metadata is for.
  * @param string    $meta_key   Metadata key.
  * @param mixed     $meta_value Metadata value. Must be serializable if non-scalar.
- * @param mixed     $prev_value Optional. If specified, only update existing metadata entries.
  */
-function link_stories_page_stories( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+function link_stories_page_stories( $check, $object_id, $meta_key, $meta_value ) {
 	if ( $meta_key !== 'stories' ) {
 		return;
 	}

--- a/inc/template-translations.php
+++ b/inc/template-translations.php
@@ -147,12 +147,9 @@ add_action( 'admin_notices', 'wmf_progress_notice' );
 /**
  * Gets a formatted array of available translations.
  *
- * @param  bool   $strict     When TRUE (default) only sites with a matching translation for requested page will be included.
- * @param  int    $content_id The ID for the content. e.g post ID.
- * @param  string $type       The type of content. Usually post.
  * @return mixed  array|bool
  */
-function wmf_get_translations( $strict = true, $content_id = 0, $type = '' ) {
+function wmf_get_translations() {
 	$translations     = wmf_multilingualpress_get_translations();
 	$ret_translations = array();
 
@@ -224,8 +221,7 @@ function wmf_get_random_translation( $key, $args = array() ) {
 	);
 
 	$args         = wp_parse_args( $args, $defaults );
-	$strict       = 'meta' === $args['source'] ? true : false;
-	$translations = wmf_get_translations( $strict );
+	$translations = wmf_get_translations();
 
 	if ( false === $translations ) {
 		return false;


### PR DESCRIPTION
This PR builds upon #238 by resolving all remaining PHPCS warnings throughout the codebase. I've opened it as a separate PR to ease review, since these changes are a little more manual / involved than the other PR. The main change to inspect here is the removal of *unused* function arguments. With the exception of `WMF\Images\Credits#set_id`, these were all trailing arguments which can be safely omitted without changing any other behavior. In that one case with `set_id` we determined the leading argument was never used, so we adjusted both the function and the code which called it.