### PR TITLE
1143: Allow full width blocks inside articles

### DIFF
--- a/assets/src/sass/content/_article.scss
+++ b/assets/src/sass/content/_article.scss
@@ -1,6 +1,4 @@
 article {
-	width: 100%;
-
 	// Handle errant h1s in old posts.
 	.single-post:not(.has-blocks) & > h1 {
 		@include h2;
@@ -183,7 +181,6 @@ article {
 
 .article-title {
 	margin: rem(45) auto;
-	max-width: rem(640);
 
 	@include responsive-margin(30, 60, bottom);
 

--- a/single.php
+++ b/single.php
@@ -75,7 +75,7 @@ while ( have_posts() ) {
 		</div>
 	<?php endif; ?>
 
-	<article class="wysiwyg is-layout-constrained">
+	<article class="wysiwyg alignfull is-layout-constrained has-global-padding">
 		<?php the_content(); ?>
 
 		<?php


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1143

- Add `alignfull` and `has-global-padding` classes to the article tag
- Remove article styles that were capping the width