### PR TITLE
1143: Ensure DOMDocument parses content as UTF-8

### DIFF
--- a/inc/editor/blocks/toc.php
+++ b/inc/editor/blocks/toc.php
@@ -42,7 +42,7 @@ function get_headings_from_post_content( string $content ): array {
 	 * @see Issue #907 for planned enhancements to this approach.
 	 */
 	libxml_use_internal_errors( true );
-	$heading_block_doc->loadHTML( '<?xml encoding="UTF-8">' . $content );
+	$heading_block_doc->loadHTML( '<meta charset="UTF-8">' . $content );
 	libxml_clear_errors(); // Clear any errors that were raised during the loadHTML operation.
 
 	$xpath = new DOMXPath( $heading_block_doc );


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1143

For the language sites, the special characters were being encoded wrong. I traced it back to DOMDocument and was able to fix it by passing in `<meta charset="UTF-8">`.