### PR TITLE
1132: Add accordion item block deprecation

### DIFF
--- a/assets/src/editor/blocks/accordion-item/deprecations.js
+++ b/assets/src/editor/blocks/accordion-item/deprecations.js
@@ -1,0 +1,43 @@
+/**
+ * Handle old versions of this block.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/
+ */
+
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import metadata from './block.json';
+metadata.attributes.title.selector = 'h3';
+
+/**
+ * Original version of accordion item block, which nested h3s inside of the button.
+ */
+const v1 = {
+	...metadata,
+	/**
+	 * Render save of the original v1 accordion item block.
+	 */
+	save( { attributes, context } ) {
+		const { fontColor, title } = attributes;
+
+		return (
+			<div className="accordion-item">
+				<button
+					className="accordion-item__title"
+					style={ fontColor && { color: fontColor } }
+				>
+					<RichText.Content
+						className="accordion-item__title-text"
+						tagName="h3"
+						value={ title }
+					/>
+				</button>
+
+				<div className="accordion-item__content">
+					<InnerBlocks.Content />
+				</div>
+			</div>
+		);
+	},
+};
+
+export default [ v1 ];

--- a/assets/src/editor/blocks/accordion-item/index.js
+++ b/assets/src/editor/blocks/accordion-item/index.js
@@ -10,6 +10,7 @@
 import { registerBlockType } from '@wordpress/blocks';
 
 import metadata from './block.json';
+import deprecated from './deprecations';
 import edit from './edit';
 import save from './save';
 
@@ -19,6 +20,7 @@ registerBlockType( metadata.name, {
 	...metadata,
 	edit,
 	save,
+	deprecated,
 } );
 
 // Block HMR boilerplate.


### PR DESCRIPTION
While working on https://github.com/wikimedia/shiro-wordpress-theme/pull/233, I couldn't get the block deprecation working. But updating the block was really annoying, so I spent some more time and figured it out. 

This PR adds block deprecation for the accordion item block so the titles update.