### PR TITLE
1159: Update accordion item block title deprecation

### DIFF
--- a/assets/src/editor/blocks/accordion-item/block.json
+++ b/assets/src/editor/blocks/accordion-item/block.json
@@ -13,8 +13,8 @@
 		},
 		"title": {
 			"type": "string",
-			"source": "html",
-			"selector": "span"
+			"source": "text",
+			"selector": ".accordion-item__title-text"
 		}
 	},
 	"usesContext": [ "accordion/fontColor" ],

--- a/assets/src/editor/blocks/accordion-item/deprecations.js
+++ b/assets/src/editor/blocks/accordion-item/deprecations.js
@@ -6,7 +6,9 @@
 
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
 import metadata from './block.json';
-metadata.attributes.title.selector = 'h3';
+metadata.attributes.title.selector =
+	'.accordion-item__title-text, .accordion-item__title-text strong';
+metadata.attributes.title.source = 'html';
 
 /**
  * Original version of accordion item block, which nested h3s inside of the button.
@@ -37,6 +39,11 @@ const v1 = {
 				</div>
 			</div>
 		);
+	},
+	migrate( { title } ) {
+		return {
+			title: title.replace( /(<([^>]+)>)/gi, '' ),
+		};
 	},
 };
 


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1159

Follows on to https://github.com/wikimedia/shiro-wordpress-theme/pull/246 to refine the block attributes and make the block deprecation more robust.

- Update accordion block attrs to use text for source and classname for selector
- Make block deprecation for accordion item block more robust by:
  - including more selectors and the old 'html' source
  - stripping the html tags before saving it to get rid of nested strong tags
