### PR TITLE
Update header styles to fix z-index with jumplist

### DIFF
--- a/assets/src/sass/components/_site-header.scss
+++ b/assets/src/sass/components/_site-header.scss
@@ -1,4 +1,11 @@
 .site-header {
+
+	// Increase the z-index to ensure compatibility with the annual report jumplist.
+	// We repeat the class for extra specificity to override core styles.
+	&.site-header {
+		z-index: 21;
+	}
+
 	@include media(">=sm_desktop") {
 		&:has( .primary-nav .wp-block-hm-mega-menu__toggle[aria-expanded=true] ) {
 			box-shadow: var(--wp--preset--shadow--shadow-16-blur);


### PR DESCRIPTION
On annual reports using the jumplist, this block appears in front of megamenu dropdowns.

We can resolve this by increasing the z-index of the header so it will appear in front.